### PR TITLE
fix(smoketests): correct props/targets filenames to match PackageId curb

### DIFF
--- a/examples/curb-cleanup-smoketest/curb-cleanup-smoketest.csproj
+++ b/examples/curb-cleanup-smoketest/curb-cleanup-smoketest.csproj
@@ -39,8 +39,8 @@
 
   <!-- The package imports props before the project and targets after it, so the sample does the same
        rather than testing an arrangement no consumer has. The targets are what set $(ErrorLog). -->
-  <Import Project="../../src/Nullean.Curb.MSBuild/build/Nullean.Curb.MSBuild.props" />
+  <Import Project="../../src/Nullean.Curb.MSBuild/build/curb.props" />
 
-  <Import Project="../../src/Nullean.Curb.MSBuild/build/Nullean.Curb.MSBuild.targets" />
+  <Import Project="../../src/Nullean.Curb.MSBuild/build/curb.targets" />
 
 </Project>

--- a/examples/curb-msbuild-smoketest/curb-msbuild-smoketest.csproj
+++ b/examples/curb-msbuild-smoketest/curb-msbuild-smoketest.csproj
@@ -26,8 +26,8 @@
 
   <!-- The package imports props before the project and targets after it, so the sample does the
        same rather than importing both at the top and testing an arrangement no consumer has. -->
-  <Import Project="../../src/Nullean.Curb.MSBuild/build/Nullean.Curb.MSBuild.props" />
+  <Import Project="../../src/Nullean.Curb.MSBuild/build/curb.props" />
 
-  <Import Project="../../src/Nullean.Curb.MSBuild/build/Nullean.Curb.MSBuild.targets" />
+  <Import Project="../../src/Nullean.Curb.MSBuild/build/curb.targets" />
 
 </Project>


### PR DESCRIPTION
## Summary

- Both `curb-msbuild-smoketest` and `curb-cleanup-smoketest` imported `Nullean.Curb.MSBuild.props`/`.targets`, which don't exist
- The actual files in `src/Nullean.Curb.MSBuild/build/` are `curb.props` and `curb.targets`, matching `PackageId: curb`
- Fixes the failing "MSBuild integration runs before the compiler" CI step

## Test plan

- [ ] CI: "MSBuild integration runs before the compiler" passes
- [ ] CI: "Cleanup fixes what the build reported, and only that" passes (uses the cleanup smoketest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)