### PR TITLE
fix: eliminate all build warnings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -151,6 +151,8 @@ dotnet_diagnostic.CA1707.severity = none
 # The document IR switches over DocKind exhaustively via `default:`; listing every member at every
 # site is noise, and a new kind should fall through to the default rather than break the build.
 dotnet_diagnostic.IDE0010.severity = none
+# Same reasoning for switch expressions: wildcard arms handle future enum values without breaking.
+dotnet_diagnostic.IDE0072.severity = none
 # Several types rent pooled buffers in their constructor, which a primary constructor cannot express.
 dotnet_diagnostic.IDE0290.severity = suggestion
 # Hot-path counters stay as fields; `Count => _count` reads better than an auto property here.

--- a/build/scripts/Targets.fs
+++ b/build/scripts/Targets.fs
@@ -1,5 +1,7 @@
 module Targets
 
+#nowarn "3391" // Nullable<int> implicit conversions from ProcNet's ExitCode
+
 open Argu
 open System
 open System.IO

--- a/tests/Nullean.Curb.Tests/Documents/DocDumperTests.cs
+++ b/tests/Nullean.Curb.Tests/Documents/DocDumperTests.cs
@@ -22,13 +22,11 @@ public class DocDumperTests
 				arena.SoftLine();
 				arena.SourceText(4, 1);       // "a"
 			}
-			using (var ifBreak = arena.IfBreak(groupId))
-			{
-				using (ifBreak.Branch())
-					arena.Synthetic(SyntheticText.Empty);
-				using (ifBreak.Branch())
-					arena.Synthetic(SyntheticText.Comma);
-			}
+			using var ifBreak = arena.IfBreak(groupId);
+			using (ifBreak.Branch())
+				arena.Synthetic(SyntheticText.Empty);
+			using (ifBreak.Branch())
+				arena.Synthetic(SyntheticText.Comma);
 		}
 
 		var dump = DocDumper.Dump(arena, Source);

--- a/tests/Nullean.Curb.Tests/Formatting/_Harness/.editorconfig
+++ b/tests/Nullean.Curb.Tests/Formatting/_Harness/.editorconfig
@@ -1,0 +1,3 @@
+[*.cs]
+# Namespace intentionally matches the parent Formatting namespace, not the _Harness organisational folder.
+dotnet_diagnostic.IDE0130.severity = none

--- a/tests/Nullean.Curb.Tests/Formatting/_Harness/FormattingTest.cs
+++ b/tests/Nullean.Curb.Tests/Formatting/_Harness/FormattingTest.cs
@@ -187,7 +187,7 @@ public abstract class FormattingTest
 internal static class ExpectationDump
 {
 	private static readonly string? Root = Environment.GetEnvironmentVariable("CURB_EXPECTATION_DUMP");
-	private static int _next;
+	private static int Next;
 
 	public static void Record(string expected, string? editorConfig)
 	{
@@ -197,7 +197,7 @@ internal static class ExpectationDump
 		// A directory each, because the expectations do not share a configuration: one asserts tab
 		// indentation, the next a width of 40. Pooling them under one .editorconfig would judge most
 		// of them against settings they were never written for.
-		var directory = Path.Combine(Root, Interlocked.Increment(ref _next).ToString("D5", CultureInfo.InvariantCulture));
+		var directory = Path.Combine(Root, Interlocked.Increment(ref Next).ToString("D5", CultureInfo.InvariantCulture));
 		Directory.CreateDirectory(directory);
 
 		File.WriteAllText(

--- a/tests/Nullean.Curb.Tests/Printing/DocPrinterTests.cs
+++ b/tests/Nullean.Curb.Tests/Printing/DocPrinterTests.cs
@@ -224,13 +224,11 @@ public class DocPrinterTests
 			// flat branch. Targeting the outer, broken group must override that.
 			using (arena.Group())
 			{
-				using (var ifBreak = arena.IfBreak(outerId))
-				{
-					using (ifBreak.Branch())
-						Text(arena, "abc");
-					using (ifBreak.Branch())
-						Text(arena, "def");
-				}
+				using var ifBreak = arena.IfBreak(outerId);
+				using (ifBreak.Branch())
+					Text(arena, "abc");
+				using (ifBreak.Branch())
+					Text(arena, "def");
 			}
 		}
 

--- a/tests/Nullean.Curb.Tests/Verification/DeclaredDeltaTests.cs
+++ b/tests/Nullean.Curb.Tests/Verification/DeclaredDeltaTests.cs
@@ -39,7 +39,7 @@ public class DeclaredDeltaTests
 	/// A word the output does not contain gets an offset nothing can match, so "declared but never appeared"
 	/// stays a failure rather than becoming an exception.
 	/// </remarks>
-	private static IReadOnlyList<InsertedToken>? Locate(string output, IReadOnlyList<string>? inserted)
+	private static List<InsertedToken>? Locate(string output, IReadOnlyList<string>? inserted)
 	{
 		if (inserted is null)
 			return null;


### PR DESCRIPTION
## Summary

- **FS3391 (×11)** — `build/scripts/Targets.fs`: adds `#nowarn "3391"` to suppress implicit `int` → `Nullable<int>` conversions when comparing ProcNet's `ExitCode` against `0`
- **IDE0072** — `.editorconfig`: suppresses "populate switch expression" globally alongside the existing IDE0010 suppression; wildcard arms are intentional for forward-compatibility with new enum values
- **IDE0130 (×3)** — new `_Harness/.editorconfig`: suppresses namespace/folder mismatch; the `Formatting` namespace is kept intentionally so test subclasses in child namespaces resolve `FormattingTest` via C# parent-namespace lookup without needing explicit `using` directives
- **IDE1006** — `FormattingTest.cs`: renames `_next` → `Next` (non-public static fields are PascalCase per project convention)
- **IDE0063 (×2)** — `DocDumperTests.cs`, `DocPrinterTests.cs`: simplifies `using (...) { }` to `using var`
- **CA1859** — `DeclaredDeltaTests.cs`: narrows `Locate` return type from `IReadOnlyList<InsertedToken>?` to `List<InsertedToken>?`

## Test plan

- [ ] CI build passes with zero warnings
- [ ] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)