### PR TITLE
Docs: clarify dnf whitespace vs dotnet format, add cold/warm section

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,22 @@ and the build integration guide.
 
 ## Why
 
-**Fast enough to run on every build.** Curb is a native-AOT binary with no warm-up cost. Measured
+**Fast enough to run on every build.** curb is a native-AOT binary with no warm-up cost. Measured
 cold on Newtonsoft.Json (945 files):
 
-| | Curb | dotnet format | CSharpier |
+| | curb | dnf whitespace | CSharpier |
 |---|---|---|---|
 | Newtonsoft.Json (945 files) | **0.26 s** | 3.47 s | 4.85 s |
 
-Across twelve real repositories Curb is 5–25× faster than `dotnet format` — fast enough to wire
-into `dotnet build` and forget about it. Full numbers: [Benchmarks](https://curb.nullean.net/benchmarks/).
+`dnf whitespace` is `dotnet format whitespace` — the whitespace-only pass, curb's closest equivalent.
+Across twelve real repositories curb is 5–25× faster than `dotnet format whitespace`, while doing
+more: it reflows long lines, sorts using directives, and applies syntax-level code style on top.
+Fast enough to wire into `dotnet build` and forget about it. Full numbers:
+[Benchmarks](https://curb.nullean.net/benchmarks/).
+
+On subsequent builds the MSBuild integration skips unchanged projects entirely — no process starts.
+For projects with changes, only the files that changed since the last build are reformatted. curb is
+FAST cold, FASTER warm.
 
 **Plays well with your IDE and `dotnet format`.** Curb supports the full set of `.editorconfig`
 formatting properties that Visual Studio, Rider and `dotnet format` read — all 39 `csharp_*` and

--- a/docs/benchmarks/index.md
+++ b/docs/benchmarks/index.md
@@ -8,22 +8,11 @@ description: A measurement run over 41,000 files of real .NET source across twel
 A measurement run over 41,000 files of real .NET source, timing three tools on identical copies of
 each repository.
 
-## Method
-
-Twelve repositories, cloned shallow, each formatted from a pristine copy. Curb is the published
-native-AOT binary, not the JIT build. All three tools are timed cold — repository and formatter cache
-cleared before each run. After formatting, `dotnet format whitespace` was run over Curb's output to
-measure agreement; Curb was also run a second time over its own output to verify idempotency. Those
-per-repository counts are in [Churn](churn.md).
-
-Two repositories have no `.editorconfig` at all (Newtonsoft.Json, ServiceStack), which is the
-onboarding case for a repository that has never configured anything.
-
 ## Results
 
 <!-- RESULTS -->
 
-| repo | files | Curb | dotnet format | CSharpier |
+| repo | files | curb | dnf whitespace | CSharpier |
 |---|---|---|---|---|
 | serilog | 216 | 0.06 s | 1.23 s | 0.73 s |
 | FluentValidation | 219 | 0.06 s | 1.48 s | 0.59 s |
@@ -40,17 +29,36 @@ onboarding case for a repository that has never configured anything.
 
 <!-- /RESULTS -->
 
+The `dnf whitespace` column is `dotnet format whitespace` — the whitespace-only pass, not the full
+style-and-analyser run. curb is compared against its closest equivalent: the tool that does the
+same job.
+
 ### Speed
 
-Curb is 5–25× faster than `dotnet format` across the corpus, on every repository. `dotnet format`
-loads the full Roslyn workspace per project and is not designed to be fast.
+curb is 5–25× faster than `dotnet format whitespace` across the corpus, on every repository, while
+doing more: `dotnet format whitespace` does not reflow long lines, does not sort using directives,
+and does not apply syntax-level code style. Beating it on raw speed while covering a strict superset
+of its output is the headline result.
 
-On unchanged projects the MSBuild stamp means no process starts at all.
+`dotnet format whitespace` loads the full Roslyn workspace per project and is not designed to be
+fast.
+
+### Cold vs warm
+
+All three tools above are timed cold — repository and formatter cache cleared before each run. Cold
+is the right baseline for comparing tools. Warm is where curb pulls further ahead.
+
+curb's subsequent runs are protected by MSBuild incremental support: if nothing changed in a project,
+no process starts at all — not even the CLI. For projects that do have changes, a local cache means
+only the files that changed since the last build are reformatted, not the whole project.
+
+The cache clears with `dotnet clean` and autoinvalidates after one week. curb is FAST cold, FASTER
+warm.
 
 ### Churn
 
 See [Churn](churn.md) for what churn means, how much to expect on first adoption, and a worked
-example. The short version: roslyn (17,167 files, already exactly `dotnet format`-clean) is Curb's
+example. The short version: roslyn (17,167 files, already exactly `dotnet format`-clean) is curb's
 sharpest case — 9,191 files rewritten, zero not-fixed-point. All of it is ground `dotnet format`
 doesn't cover: BOM handling, using-directive sorting, chain breaking, comment alignment.
 
@@ -63,4 +71,15 @@ Shallow-clone the twelve repositories into a single directory, then:
 ```
 
 The results table above is written back into this file automatically. The run takes roughly 40 minutes
-wall clock, dominated by `dotnet format` on roslyn and efcore.
+wall clock, dominated by `dotnet format whitespace` on roslyn and efcore.
+
+## Method
+
+Twelve repositories, cloned shallow, each formatted from a pristine copy. curb is the published
+native-AOT binary, not the JIT build. All three tools are timed cold — repository and formatter cache
+cleared before each run. After formatting, `dotnet format whitespace` was run over curb's output to
+measure agreement; curb was also run a second time over its own output to verify idempotency. Those
+per-repository counts are in [Churn](churn.md).
+
+Two repositories have no `.editorconfig` at all (Newtonsoft.Json, ServiceStack), which is the
+onboarding case for a repository that has never configured anything.

--- a/docs/design-principles/performance.md
+++ b/docs/design-principles/performance.md
@@ -15,7 +15,7 @@ Measured on a 6.5 MB corpus (1,196 files), as CPU time:
 
 Parsing is about 2.5% of the budget. Roughly 97% of what a formatter costs is its own work. {{product}} adds almost nothing on top of the parse: it is within measurement noise of the floor.
 
-The [twelve-repository comparison](../benchmarks/index.md) has wall-clock numbers across real repositories; on roslyn (17,167 files) {{product}} takes **7 s** against `dotnet format`'s **34 s**.
+The [twelve-repository comparison](../benchmarks/index.md) has wall-clock numbers across real repositories; on roslyn (17,167 files) {{product}} takes **7 s** against `dotnet format whitespace`'s **34 s**.
 
 ## Why it is fast
 

--- a/docs/why.md
+++ b/docs/why.md
@@ -12,12 +12,15 @@ placement.
 ## It's fast
 
 0.26 s on 945 files (Newtonsoft.Json), cold. `dotnet format whitespace` on the same files: 3.47 s.
-Across twelve real repositories, Curb is 5–25× faster. See [Benchmarks](benchmarks/index.md) for
-the full table.
+Across twelve real repositories, curb is 5–25× faster than `dotnet format whitespace` — and does
+more: reflow to line width, using-directive sorting, and syntax-level code style on top. See
+[Benchmarks](benchmarks/index.md) for the full table.
 
-Speed is what makes running on every build viable. The [build integration](workflow/msbuild.md)
-skips unchanged projects entirely via MSBuild's stamp mechanism; on a project where nothing changed,
-no process starts.
+Speed is what makes running on every build viable. All benchmark numbers are cold. Warm runs are
+faster still: the [build integration](workflow/msbuild.md) skips unchanged projects entirely —
+no process starts. For projects with changes, only the files that changed since the last build are
+reformatted. The local cache autoinvalidates after one week and clears with `dotnet clean`. curb is
+FAST cold, FASTER warm.
 
 ## It doesn't fight what you already run
 


### PR DESCRIPTION
## Summary

- Rename benchmark table headers: `Curb` → `curb`, `dotnet format` → `dnf whitespace`, with an inline note that `dnf whitespace` = `dotnet format whitespace`. Curb is compared against its true peer — the whitespace-only pass — not the slower full style+analyser run. Being faster while doing a strict superset is the stronger claim.
- Expand speed prose in `benchmarks/index.md`, `why.md`, and `README` to surface that curb beats `dotnet format whitespace` while covering more ground (reflow, using sorting, syntax-level code style).
- Add a **Cold vs warm** section to the benchmarks page: all timed numbers are cold; MSBuild incremental means warm runs skip unchanged projects entirely and reformat only changed files via the local cache; cache autoinvalidates after a week and clears with `dotnet clean`; "FAST cold, FASTER warm."
- Fix a bare `dotnet format` reference in `performance.md` that should have said `dotnet format whitespace`.

## Test plan

- [ ] `./build.sh docs` builds cleanly and the benchmarks page renders with the renamed headers and new Cold vs warm section
- [ ] README renders correctly on GitHub (table, explanation note, warm-run paragraph)