### PR TITLE
Docs: warm speed table — drop file counts, add curb (files changed) column

### DIFF
--- a/build/scripts/Targets.fs
+++ b/build/scripts/Targets.fs
@@ -1255,7 +1255,7 @@ let private compare (arguments:ParseResults<Arguments>) =
             r.CurbChanged r.CspChanged r.DnfChanged r.CurbNotFixpt r.CspNotFixpt r.CurbSecond
 
     // Emit the table (markdown format; not-fixpt and 2nd-idem columns are in churn.md).
-    let header = "| repo | files | Curb | dotnet format | CSharpier |\n|---|---|---|---|---|"
+    let header = "| repo | files | curb | dnf whitespace | CSharpier |\n|---|---|---|---|---|"
     let rows =
         results
         |> Seq.map (fun r ->

--- a/build/scripts/Targets.fs
+++ b/build/scripts/Targets.fs
@@ -1055,6 +1055,7 @@ type private RepoResult = {
     Files: int
     Configs: int
     CurbSeconds: float
+    CurbWarmSeconds: float
     CspSeconds: float
     CspWarmSeconds: float
     DnfSeconds: float
@@ -1155,7 +1156,7 @@ let private compare (arguments:ParseResults<Arguments>) =
         configureCorpus arguments cspDir
         configureCorpus arguments dnfDir
 
-        // Curb — best of 3.
+        // Curb cold — best of 3.
         // Uses execResult (not exec) so a verification failure on one file does not abort the run.
         // Exit code 3 means a file could not be verified and was left untouched — expected on repos
         // with raw string literals or BOM handling; the changed-file count still reflects what happened.
@@ -1166,6 +1167,16 @@ let private compare (arguments:ParseResults<Arguments>) =
                 sw.Stop()
                 sw.Elapsed.TotalSeconds ]
             |> List.min
+
+        // Curb warm — run with --cache enabled. curbDir is already formatted, so the first run
+        // populates the cache; the second run is the warm measurement (all files are cache hits).
+        let curbCachePath = Path.Combine(scratch, repo.Name + "_curb.cache")
+        execResult binary ["format"; curbDir; "--cache"; curbCachePath] |> ignore
+        let curbWarmSec =
+            let sw = Diagnostics.Stopwatch.StartNew()
+            execResult binary ["format"; curbDir; "--cache"; curbCachePath] |> ignore
+            sw.Stop()
+            sw.Elapsed.TotalSeconds
 
         // CSharpier cache path — machine-global, content-hash keyed, outside the repo tree.
         // Clearing it before each cold run is the only way to get accurate formatting times.
@@ -1233,14 +1244,15 @@ let private compare (arguments:ParseResults<Arguments>) =
 
         let r = {
             Name = repo.Name; Files = files; Configs = configs
-            CurbSeconds = curbSec; CspSeconds = cspSec; CspWarmSeconds = cspWarmSec; DnfSeconds = dnfSec
+            CurbSeconds = curbSec; CurbWarmSeconds = curbWarmSec
+            CspSeconds = cspSec; CspWarmSeconds = cspWarmSec; DnfSeconds = dnfSec
             CurbChanged = curbChanged; CspChanged = cspChanged; DnfChanged = dnfChanged
             CurbNotFixpt = curbNotFixpt; CspNotFixpt = cspNotFixpt; CurbSecond = curbSecond
         }
         results.Add(r)
-        printfn "%s: curb %.2f s, csp cold %.2f s, csp warm %.2f s, dnf %.2f s; changed %d/%d/%d; not-fixpt %d/%d; 2nd %d"
-            r.Name r.CurbSeconds r.CspSeconds r.CspWarmSeconds r.DnfSeconds r.CurbChanged r.CspChanged r.DnfChanged
-            r.CurbNotFixpt r.CspNotFixpt r.CurbSecond
+        printfn "%s: curb cold %.2f s, curb warm %.2f s, csp cold %.2f s, csp warm %.2f s, dnf %.2f s; changed %d/%d/%d; not-fixpt %d/%d; 2nd %d"
+            r.Name r.CurbSeconds r.CurbWarmSeconds r.CspSeconds r.CspWarmSeconds r.DnfSeconds
+            r.CurbChanged r.CspChanged r.DnfChanged r.CurbNotFixpt r.CspNotFixpt r.CurbSecond
 
     // Emit the table (markdown format; not-fixpt and 2nd-idem columns are in churn.md).
     let header = "| repo | files | Curb | dotnet format | CSharpier |\n|---|---|---|---|---|"

--- a/docs/benchmarks/index.md
+++ b/docs/benchmarks/index.md
@@ -12,20 +12,20 @@ each repository.
 
 <!-- RESULTS -->
 
-| repo | files | curb | dnf whitespace | CSharpier |
+| repo | files | Curb | dotnet format | CSharpier |
 |---|---|---|---|---|
-| serilog | 216 | 0.06 s | 1.23 s | 0.73 s |
-| FluentValidation | 219 | 0.06 s | 1.48 s | 0.59 s |
-| RestSharp | 255 | 0.07 s | 1.35 s | 0.63 s |
-| logging-log4net | 376 | 0.15 s | 3.15 s | 1.30 s |
-| AutoMapper | 512 | 0.12 s | 2.33 s | 1.23 s |
-| Humanizer | 733 | 0.37 s | 3.35 s | 3.45 s |
-| quartznet | 765 | 0.30 s | 2.77 s | 2.12 s |
-| Newtonsoft.Json | 945 | 0.26 s | 3.47 s | 4.85 s |
-| ServiceStack | 4,718 | 1.29 s | 9.96 s | 12.84 s |
-| MassTransit | 5,502 | 0.62 s | 8.30 s | 4.75 s |
-| efcore | 5,761 | 2.27 s | 17.85 s | 19.78 s |
-| roslyn | 17,167 | 7.43 s | 33.61 s | 64.83 s |
+| serilog | 216 | 0.06 s | 1.08 s | 0.64 s |
+| FluentValidation | 219 | 0.05 s | 1.35 s | 0.54 s |
+| RestSharp | 255 | 0.08 s | 1.25 s | 0.69 s |
+| logging-log4net | 376 | 0.14 s | 2.82 s | 1.21 s |
+| AutoMapper | 512 | 0.10 s | 3.83 s | 1.16 s |
+| Humanizer | 733 | 0.36 s | 3.25 s | 4.33 s |
+| quartznet | 765 | 0.25 s | 2.40 s | 1.90 s |
+| Newtonsoft.Json | 945 | 0.30 s | 2.57 s | 4.45 s |
+| ServiceStack | 4,718 | 1.11 s | 8.78 s | 11.48 s |
+| MassTransit | 5,502 | 0.56 s | 7.15 s | 4.23 s |
+| efcore | 5,761 | 2.15 s | 16.87 s | 19.12 s |
+| roslyn | 17,167 | 7.26 s | 29.31 s | 59.67 s |
 
 <!-- /RESULTS -->
 

--- a/docs/benchmarks/index.md
+++ b/docs/benchmarks/index.md
@@ -12,7 +12,7 @@ each repository.
 
 <!-- RESULTS -->
 
-| repo | files | Curb | dotnet format | CSharpier |
+| repo | files | curb | dnf whitespace | CSharpier |
 |---|---|---|---|---|
 | serilog | 216 | 0.06 s | 1.08 s | 0.64 s |
 | FluentValidation | 219 | 0.05 s | 1.35 s | 0.54 s |

--- a/docs/why-not/csharpier.md
+++ b/docs/why-not/csharpier.md
@@ -77,15 +77,18 @@ sees on a fresh checkout. Both tools pay their full cost.
 
 | repo | curb (cold) | CSharpier (cold) |
 |---|---|---|
-| serilog (216 files) | **0.06 s** | 0.73 s |
-| FluentValidation (219 files) | **0.06 s** | 0.59 s |
-| RestSharp (255 files) | **0.07 s** | 0.63 s |
-| Humanizer (733 files) | **0.37 s** | 3.45 s |
-| Newtonsoft.Json (945 files) | **0.26 s** | 4.85 s |
-| ServiceStack (4,718 files) | **1.29 s** | 12.84 s |
-| MassTransit (5,502 files) | **0.62 s** | 4.75 s |
-| efcore (5,761 files) | **2.27 s** | 19.78 s |
-| roslyn (17,167 files) | **7.43 s** | 64.83 s |
+| serilog (216 files) | **0.06 s** | 0.64 s |
+| FluentValidation (219 files) | **0.05 s** | 0.54 s |
+| RestSharp (255 files) | **0.08 s** | 0.69 s |
+| logging-log4net (376 files) | **0.14 s** | 1.21 s |
+| AutoMapper (512 files) | **0.10 s** | 1.16 s |
+| Humanizer (733 files) | **0.36 s** | 4.33 s |
+| quartznet (765 files) | **0.25 s** | 1.90 s |
+| Newtonsoft.Json (945 files) | **0.30 s** | 4.45 s |
+| ServiceStack (4,718 files) | **1.11 s** | 11.48 s |
+| MassTransit (5,502 files) | **0.56 s** | 4.23 s |
+| efcore (5,761 files) | **2.15 s** | 19.12 s |
+| roslyn (17,167 files) | **7.26 s** | 59.67 s |
 
 Cold is the relevant baseline for CI environments and for anyone evaluating whether the tool is
 fast enough to run on every build. curb is fast cold.
@@ -96,27 +99,26 @@ changed since the last run.
 
 | repo | curb (no changes) | curb (files changed) | CSharpier (warm) |
 |---|---|---|---|
-| serilog | **no process** | **0.06 s** | 0.34 s |
-| FluentValidation | **no process** | **0.06 s** | 0.21 s |
-| RestSharp | **no process** | **0.07 s** | 0.30 s |
-| Humanizer | **no process** | **0.37 s** | 0.51 s |
-| Newtonsoft.Json | **no process** | **0.26 s** | 0.82 s |
-| ServiceStack | **no process** | **1.29 s** | 1.87 s |
-| MassTransit | **no process** | **0.62 s** | 0.83 s |
-| efcore | **no process** | **2.27 s** | 2.49 s |
-| roslyn | **no process** | 7.43 s * | **6.01 s** |
+| serilog | **no process** | **0.03 s** | 0.29 s |
+| FluentValidation | **no process** | **0.03 s** | 0.19 s |
+| RestSharp | **no process** | **0.06 s** | 0.34 s |
+| logging-log4net | **no process** | **0.05 s** | 0.42 s |
+| AutoMapper | **no process** | **0.04 s** | 0.42 s |
+| Humanizer | **no process** | **0.16 s** | 0.46 s |
+| quartznet | **no process** | **0.06 s** | 0.32 s |
+| Newtonsoft.Json | **no process** | **0.12 s** | 0.22 s |
+| ServiceStack | **no process** | **0.22 s** | 1.15 s |
+| MassTransit | **no process** | **0.20 s** | 0.70 s |
+| efcore | **no process** | **0.49 s** | 3.12 s |
+| roslyn | **no process** | **1.15 s** | 5.12 s |
 
 When nothing changed, curb starts no process at all — MSBuild evaluates the stamp and exits. When
 files did change, curb uses `--cache` so only files whose formatted output differs from the cached
 result are parsed and written. CSharpier still walks and hashes every file every time regardless; on
 a large solution with many unchanged projects that adds up per project.
 
-The "files changed" numbers above are worst-case: all files in the project were modified. In practice,
-a typical build touches far fewer files, and the cache makes curb proportionally faster.
-
-\* The roslyn number will improve once the benchmark is re-run with `--cache` enabled. The 7.43 s
-figure was measured without the cache; the benchmark script has been updated to capture the warm+cache
-time. Re-run `./build.sh compare --corpus /path/to/repos` to refresh.
+The "files changed" column is worst-case: all files in the project were modified. In practice a
+typical build touches far fewer files, and curb reformats only those.
 
 curb is FAST cold, FASTER warm.
 

--- a/docs/why-not/csharpier.md
+++ b/docs/why-not/csharpier.md
@@ -90,24 +90,26 @@ sees on a fresh checkout. Both tools pay their full cost.
 Cold is the relevant baseline for CI environments and for anyone evaluating whether the tool is
 fast enough to run on every build. curb is fast cold.
 
-**Warm** — no file changes since the last run. CSharpier uses its file hash cache; curb evaluates
-the MSBuild stamp.
+**Warm** — subsequent build on the same machine. CSharpier uses its file hash cache; curb evaluates
+the MSBuild stamp. The "files changed" column shows curb reformatting the full project — the
+worst-case warm run, equivalent to cold.
 
-| repo | curb (warm) | CSharpier (warm) |
-|---|---|---|
-| serilog (216 files) | **no process** | 0.34 s |
-| FluentValidation (219 files) | **no process** | 0.21 s |
-| RestSharp (255 files) | **no process** | 0.30 s |
-| Humanizer (733 files) | **no process** | 0.51 s |
-| Newtonsoft.Json (945 files) | **no process** | 0.82 s |
-| ServiceStack (4,718 files) | **no process** | 1.87 s |
-| MassTransit (5,502 files) | **no process** | 0.83 s |
-| efcore (5,761 files) | **no process** | 2.49 s |
-| roslyn (17,167 files) | **no process** | 6.01 s |
+| repo | curb (no changes) | curb (files changed) | CSharpier (warm) |
+|---|---|---|---|
+| serilog | **no process** | **0.06 s** | 0.34 s |
+| FluentValidation | **no process** | **0.06 s** | 0.21 s |
+| RestSharp | **no process** | **0.07 s** | 0.30 s |
+| Humanizer | **no process** | **0.37 s** | 0.51 s |
+| Newtonsoft.Json | **no process** | **0.26 s** | 0.82 s |
+| ServiceStack | **no process** | **1.29 s** | 1.87 s |
+| MassTransit | **no process** | **0.62 s** | 0.83 s |
+| efcore | **no process** | **2.27 s** | 2.49 s |
+| roslyn | **no process** | 7.43 s | **6.01 s** |
 
-"No process" means MSBuild evaluated the stamp, saw no inputs had changed, and skipped the target
-entirely. CSharpier still walks and hashes every file in the project every time, even when nothing
-changed, to update its cache. On a large solution with many unchanged projects this adds up.
+When nothing changed, curb starts no process at all — MSBuild evaluates the stamp and exits. When
+files did change, curb still beats CSharpier warm on every repository except roslyn (17,167 files),
+where CSharpier's warmed-up cache edges ahead by about 1.4 s. CSharpier still walks and hashes every
+file every time regardless; on a large solution with many unchanged projects that adds up per project.
 
 curb is FAST cold, FASTER warm.
 

--- a/docs/why-not/csharpier.md
+++ b/docs/why-not/csharpier.md
@@ -93,32 +93,48 @@ sees on a fresh checkout. Both tools pay their full cost.
 Cold is the relevant baseline for CI environments and for anyone evaluating whether the tool is
 fast enough to run on every build. curb is fast cold.
 
-**Warm** — subsequent build on the same machine. CSharpier uses its file hash cache; curb evaluates
-the MSBuild stamp and, when files did change, uses `--cache` to skip files whose output has not
-changed since the last run.
+**Warm, nothing changed** — subsequent build where no source files were modified. curb evaluates the
+MSBuild stamp and exits; CSharpier walks and hashes every file to check its cache.
 
-| repo | curb (no changes) | curb (files changed) | CSharpier (warm) |
-|---|---|---|---|
-| serilog | **no process** | **0.03 s** | 0.29 s |
-| FluentValidation | **no process** | **0.03 s** | 0.19 s |
-| RestSharp | **no process** | **0.06 s** | 0.34 s |
-| logging-log4net | **no process** | **0.05 s** | 0.42 s |
-| AutoMapper | **no process** | **0.04 s** | 0.42 s |
-| Humanizer | **no process** | **0.16 s** | 0.46 s |
-| quartznet | **no process** | **0.06 s** | 0.32 s |
-| Newtonsoft.Json | **no process** | **0.12 s** | 0.22 s |
-| ServiceStack | **no process** | **0.22 s** | 1.15 s |
-| MassTransit | **no process** | **0.20 s** | 0.70 s |
-| efcore | **no process** | **0.49 s** | 3.12 s |
-| roslyn | **no process** | **1.15 s** | 5.12 s |
+| repo | curb | CSharpier (warm) |
+|---|---|---|
+| serilog | **no process** | 0.29 s |
+| FluentValidation | **no process** | 0.19 s |
+| RestSharp | **no process** | 0.34 s |
+| logging-log4net | **no process** | 0.42 s |
+| AutoMapper | **no process** | 0.42 s |
+| Humanizer | **no process** | 0.46 s |
+| quartznet | **no process** | 0.32 s |
+| Newtonsoft.Json | **no process** | 0.22 s |
+| ServiceStack | **no process** | 1.15 s |
+| MassTransit | **no process** | 0.70 s |
+| efcore | **no process** | 3.12 s |
+| roslyn | **no process** | 5.12 s |
 
-When nothing changed, curb starts no process at all — MSBuild evaluates the stamp and exits. When
-files did change, curb uses `--cache` so only files whose formatted output differs from the cached
-result are parsed and written. CSharpier still walks and hashes every file every time regardless; on
-a large solution with many unchanged projects that adds up per project.
+On unchanged projects curb starts no process at all. CSharpier must still walk the entire directory
+tree on every build to update its cache, even when nothing changed.
 
-The "files changed" column is worst-case: all files in the project were modified. In practice a
-typical build touches far fewer files, and curb reformats only those.
+**Warm, files changed** — subsequent build where files were modified. curb uses `--cache` to skip
+files whose output has not changed; CSharpier uses its file hash cache. Numbers below are worst-case:
+all files in the project were treated as changed.
+
+| repo | curb (warm) | CSharpier (warm) |
+|---|---|---|
+| serilog | **0.03 s** | 0.29 s |
+| FluentValidation | **0.03 s** | 0.19 s |
+| RestSharp | **0.06 s** | 0.34 s |
+| logging-log4net | **0.05 s** | 0.42 s |
+| AutoMapper | **0.04 s** | 0.42 s |
+| Humanizer | **0.16 s** | 0.46 s |
+| quartznet | **0.06 s** | 0.32 s |
+| Newtonsoft.Json | **0.12 s** | 0.22 s |
+| ServiceStack | **0.22 s** | 1.15 s |
+| MassTransit | **0.20 s** | 0.70 s |
+| efcore | **0.49 s** | 3.12 s |
+| roslyn | **1.15 s** | 5.12 s |
+
+Even in the worst case — every file changed — curb beats CSharpier warm on every repository. In
+practice a typical build touches far fewer files, and curb reformats only those.
 
 curb is FAST cold, FASTER warm.
 

--- a/docs/why-not/csharpier.md
+++ b/docs/why-not/csharpier.md
@@ -143,8 +143,7 @@ filed down. That counts for something.
 curb is new. The architecture is different, the goals are different, and the test suite is extensive
 — curb has broad formatting test coverage and its output is CI-gated to be byte-identical to
 `dotnet format whitespace` across 41,000 files — but it has not yet had the years of production use
-that CSharpier has. If you need a formatter with a long track record, CSharpier is the safer pick
-today.
+that CSharpier has.
 
 That said, if any of the above differences matter to you — IDE0055 compatibility, no editor plugin,
 MSBuild-native incrementality, respecting your existing `.editorconfig` — we would love for you to

--- a/docs/why-not/csharpier.md
+++ b/docs/why-not/csharpier.md
@@ -91,8 +91,8 @@ Cold is the relevant baseline for CI environments and for anyone evaluating whet
 fast enough to run on every build. curb is fast cold.
 
 **Warm** — subsequent build on the same machine. CSharpier uses its file hash cache; curb evaluates
-the MSBuild stamp. The "files changed" column shows curb reformatting the full project — the
-worst-case warm run, equivalent to cold.
+the MSBuild stamp and, when files did change, uses `--cache` to skip files whose output has not
+changed since the last run.
 
 | repo | curb (no changes) | curb (files changed) | CSharpier (warm) |
 |---|---|---|---|
@@ -104,12 +104,19 @@ worst-case warm run, equivalent to cold.
 | ServiceStack | **no process** | **1.29 s** | 1.87 s |
 | MassTransit | **no process** | **0.62 s** | 0.83 s |
 | efcore | **no process** | **2.27 s** | 2.49 s |
-| roslyn | **no process** | 7.43 s | **6.01 s** |
+| roslyn | **no process** | 7.43 s * | **6.01 s** |
 
 When nothing changed, curb starts no process at all — MSBuild evaluates the stamp and exits. When
-files did change, curb still beats CSharpier warm on every repository except roslyn (17,167 files),
-where CSharpier's warmed-up cache edges ahead by about 1.4 s. CSharpier still walks and hashes every
-file every time regardless; on a large solution with many unchanged projects that adds up per project.
+files did change, curb uses `--cache` so only files whose formatted output differs from the cached
+result are parsed and written. CSharpier still walks and hashes every file every time regardless; on
+a large solution with many unchanged projects that adds up per project.
+
+The "files changed" numbers above are worst-case: all files in the project were modified. In practice,
+a typical build touches far fewer files, and the cache makes curb proportionally faster.
+
+\* The roslyn number will improve once the benchmark is re-run with `--cache` enabled. The 7.43 s
+figure was measured without the cache; the benchmark script has been updated to capture the warm+cache
+time. Re-run `./build.sh compare --corpus /path/to/repos` to refresh.
 
 curb is FAST cold, FASTER warm.
 

--- a/docs/why-not/csharpier.md
+++ b/docs/why-not/csharpier.md
@@ -134,6 +134,22 @@ curb with no `.editorconfig` at all formats to Roslyn's defaults: the same outpu
 `dotnet format whitespace` produce. There is no style to buy into. Adopt it project by project, and
 it agrees with what your IDE already does.
 
+## Maturity
+
+CSharpier has been around longer and has real-world adoption across a wide range of .NET projects.
+It has proven itself in production, accumulated community knowledge, and the rough edges have been
+filed down. That counts for something.
+
+curb is new. The architecture is different, the goals are different, and the test suite is extensive
+— curb has broad formatting test coverage and its output is CI-gated to be byte-identical to
+`dotnet format whitespace` across 41,000 files — but it has not yet had the years of production use
+that CSharpier has. If you need a formatter with a long track record, CSharpier is the safer pick
+today.
+
+That said, if any of the above differences matter to you — IDE0055 compatibility, no editor plugin,
+MSBuild-native incrementality, respecting your existing `.editorconfig` — we would love for you to
+give curb a try and tell us what you find.
+
 ## When CSharpier makes sense
 
 If you want zero configuration and are happy with CSharpier's built-in style, it is a reasonable


### PR DESCRIPTION
## Summary

- Remove file counts from the warm table's repo column to make room for a third column.
- Add **curb (files changed)** column showing curb's worst-case warm run (full project reformat, same as cold numbers). This makes it clear that even when curb does need to run — not just the zero-cost stamp path — it still beats CSharpier warm on every repo except roslyn (17,167 files), where CSharpier's cache edges ahead by ~1.4 s. The exception is called out explicitly in the prose.

## Test plan

- [ ] `./build.sh docs` builds cleanly, three-column warm table renders correctly