### PR TITLE
Un-skip dotnet_sort_system_directives_first test

### DIFF
--- a/tests/Nullean.Curb.Tests/Formatting/Declarations/NamespaceAndUsingTests.cs
+++ b/tests/Nullean.Curb.Tests/Formatting/Declarations/NamespaceAndUsingTests.cs
@@ -170,7 +170,6 @@ public class NamespaceAndUsingTests : FormattingTest
 		""");
 
 	[Test]
-	[Skip("dotnet_sort_system_directives_first is not implemented — usings are never reordered")]
 	public Task System_usings_sort_to_the_top() => Formats(
 		"""
 		using Octokit;


### PR DESCRIPTION
## Summary
- `dotnet_sort_system_directives_first` turns out to already be fully implemented — `UsingOrganiser.cs` handles it via `UsingOrder.SystemFirst`, wired up through `EditorConfigOptionsBinder` and `FormatOptions.SortUsings`, and it's already documented in `docs/reference/usings/dotnet_sort_system_directives_first.md`.
- The only thing wrong was a stale `[Skip("dotnet_sort_system_directives_first is not implemented — usings are never reordered")]` attribute on its test, left over from before the feature landed.
- Removed the skip; the test passes as written.

Closes #22

## Test plan
- [x] `System_usings_sort_to_the_top` passes un-skipped
- [x] `./build.sh test` — 1076 passed, 0 failed, skip count dropped from 13 to 12 (exactly this test), no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)