### PR TITLE
Always collapse an empty catch/finally to `{ }`

### DIFF
--- a/src/Nullean.Curb.Core/Printing/CSharp/Printers.Statements.cs
+++ b/src/Nullean.Curb.Core/Printing/CSharp/Printers.Statements.cs
@@ -437,7 +437,10 @@ internal static partial class Printers
 				TokenPrinter.Print(catchClause.Filter.CloseParenToken, context);
 			}
 
-			PrintStatementBody(catchClause.Block, BraceStyle.ControlBlocks, context);
+			// An empty catch always prints as `catch { }`, whatever csharp_preserve_single_line_blocks
+			// says and whatever the source had — see PrintStatementBody's alwaysJoinsEmpty. A non-empty
+			// body is unaffected: it follows the block's own rule, same as any other braced construct.
+			PrintStatementBody(catchClause.Block, BraceStyle.ControlBlocks, context, alwaysJoinsEmpty: true);
 		}
 
 		if (node.Finally is null)
@@ -445,7 +448,8 @@ internal static partial class Printers
 
 		BeforeContinuation(context.Options.NewLineBeforeFinally, followsABrace: true, context);
 		TokenPrinter.Print(node.Finally.FinallyKeyword, context);
-		PrintStatementBody(node.Finally.Block, BraceStyle.ControlBlocks, context);
+		// Same reasoning as catch, above.
+		PrintStatementBody(node.Finally.Block, BraceStyle.ControlBlocks, context, alwaysJoinsEmpty: true);
 	}
 
 	public static void UsingStatement(UsingStatementSyntax node, PrintContext context)

--- a/src/Nullean.Curb.Core/Printing/CSharp/Printers.cs
+++ b/src/Nullean.Curb.Core/Printing/CSharp/Printers.cs
@@ -1459,9 +1459,27 @@ internal static partial class Printers
 	/// is on its own line. dotnet format keeps them: with statements off and blocks on,
 	/// <c>if (a) { return; }</c> becomes <c>if (a)</c> then <c>{ return; }</c>, not a full expansion.
 	/// </remarks>
-	internal static void PrintStatementBody(SyntaxNode body, BraceStyle construct, PrintContext context)
+	/// <param name="body">The braced body to emit.</param>
+	/// <param name="construct">Which csharp_new_line_before_open_brace flag governs its brace.</param>
+	/// <param name="context">Per-file printing state.</param>
+	/// <param name="alwaysJoinsEmpty">
+	/// True for a <c>catch</c> or <c>finally</c> block: an empty one always prints as <c>{ }</c> glued
+	/// to whatever precedes it (the keyword, or its declaration/filter), whatever the source had and
+	/// whatever <c>csharp_preserve_single_line_blocks</c> says. Curb's own opinion, not dotnet format's
+	/// — dotnet format is lazy about this pair in both directions, so there is nothing of its to match
+	/// either way, and an unconditional <c>{ }</c> is the cleaner default. A non-empty body is
+	/// unaffected: it follows the same rule as any other braced construct. Ignored when the body is
+	/// not empty, and when <c>csharp_empty_block_style</c> is set — an explicit opinion beats an
+	/// implicit one.
+	/// </param>
+	internal static void PrintStatementBody(
+		SyntaxNode body,
+		BraceStyle construct,
+		PrintContext context,
+		bool alwaysJoinsEmpty = false)
 	{
-		var joinsHeader = JoinsEmptyBracesToHeader(body, context);
+		var forcesEmptyJoin = alwaysJoinsEmpty && context.Options.EmptyBlockStyle is null && IsEmptyBraces(body);
+		var joinsHeader = forcesEmptyJoin || JoinsEmptyBracesToHeader(body, context);
 		var flat = joinsHeader || KeepsOneLine(body, context) || CollapsesEmptyBraces(body, context);
 
 		if (joinsHeader)

--- a/tests/Nullean.Curb.Tests/Formatting/Options/NewLineBeforeContinuationTests.cs
+++ b/tests/Nullean.Curb.Tests/Formatting/Options/NewLineBeforeContinuationTests.cs
@@ -206,9 +206,7 @@ public class NewLineBeforeContinuationTests : FormattingTest
 		        try
 		        {
 		        }
-		        catch (Exception e)
-		        {
-		        }
+		        catch (Exception e) { }
 		    }
 		}
 		""");
@@ -236,9 +234,7 @@ public class NewLineBeforeContinuationTests : FormattingTest
 		    {
 		        try
 		        {
-		        } catch (Exception e)
-		        {
-		        }
+		        } catch (Exception e) { }
 		    }
 		}
 		""",
@@ -273,13 +269,7 @@ public class NewLineBeforeContinuationTests : FormattingTest
 		    {
 		        try
 		        {
-		        } catch (ArgumentException)
-		        {
-		        } catch (Exception e) when (e.Message.Length > 0)
-		        {
-		        } catch
-		        {
-		        }
+		        } catch (ArgumentException) { } catch (Exception e) when (e.Message.Length > 0) { } catch { }
 		    }
 		}
 		""",
@@ -310,9 +300,7 @@ public class NewLineBeforeContinuationTests : FormattingTest
 		        try
 		        {
 		        }
-		        finally
-		        {
-		        }
+		        finally { }
 		    }
 		}
 		""");
@@ -340,9 +328,7 @@ public class NewLineBeforeContinuationTests : FormattingTest
 		    {
 		        try
 		        {
-		        } finally
-		        {
-		        }
+		        } finally { }
 		    }
 		}
 		""",
@@ -375,11 +361,7 @@ public class NewLineBeforeContinuationTests : FormattingTest
 		        try
 		        {
 		        }
-		        catch (Exception e)
-		        {
-		        } finally
-		        {
-		        }
+		        catch (Exception e) { } finally { }
 		    }
 		}
 		""",
@@ -424,11 +406,7 @@ public class NewLineBeforeContinuationTests : FormattingTest
 		            } else
 		            {
 		            }
-		        } catch (Exception e)
-		        {
-		        } finally
-		        {
-		        }
+		        } catch (Exception e) { } finally { }
 		    }
 		}
 		""",
@@ -448,9 +426,7 @@ public class NewLineBeforeContinuationTests : FormattingTest
 		        try
 		        {
 		        }
-		        finally
-		        {
-		        }
+		        finally { }
 		    }
 		}
 		""",

--- a/tests/Nullean.Curb.Tests/Formatting/Options/NewLineBeforeOpenBraceTests.cs
+++ b/tests/Nullean.Curb.Tests/Formatting/Options/NewLineBeforeOpenBraceTests.cs
@@ -311,10 +311,8 @@ public class NewLineBeforeOpenBraceTests : FormattingTest
 		    {
 		        try {
 		        }
-		        catch (Exception e) {
-		        }
-		        finally {
-		        }
+		        catch (Exception e) { }
+		        finally { }
 		    }
 		}
 		""",

--- a/tests/Nullean.Curb.Tests/Formatting/Options/ParenthesisSpacingTests.cs
+++ b/tests/Nullean.Curb.Tests/Formatting/Options/ParenthesisSpacingTests.cs
@@ -131,9 +131,7 @@ public class ParenthesisSpacingTests : FormattingTest
 		        try
 		        {
 		        }
-		        catch ( Exception e ) when ( a )
-		        {
-		        }
+		        catch ( Exception e ) when ( a ) { }
 		    }
 		}
 		""",

--- a/tests/Nullean.Curb.Tests/Formatting/Options/PreserveSingleLineTests.cs
+++ b/tests/Nullean.Curb.Tests/Formatting/Options/PreserveSingleLineTests.cs
@@ -311,9 +311,7 @@ public class PreserveSingleLineTests : FormattingTest
 		        try
 		        {
 		        }
-		        catch (Exception e)
-		        {
-		        }
+		        catch (Exception e) { }
 		    }
 		}
 		""");
@@ -397,8 +395,12 @@ public class PreserveSingleLineTests : FormattingTest
 		""",
 		editorConfig: "csharp_preserve_single_line_statements = false");
 
+	/// <summary>
+	/// An empty catch is Curb's one unconditional opinion in this family: <c>{ }</c> whatever these
+	/// options say. See <see href="https://github.com/nullean/curb/issues/25">issue #25</see> and
+	/// <c>Printers.Statements.JoinsClauseToBlock</c> for why.
+	/// </summary>
 	[Test]
-	[Skip("dotnet format keeps an empty `catch { }` collapsed even with both preserve options off; Curb expands it like any other block")]
 	public Task An_empty_catch_stays_collapsed_when_everything_else_expands() => Formats(
 		"""
 		public class C

--- a/tests/Nullean.Curb.Tests/Formatting/Options/SpacingTests.cs
+++ b/tests/Nullean.Curb.Tests/Formatting/Options/SpacingTests.cs
@@ -187,9 +187,7 @@ public class SpacingTests : FormattingTest
 		        try
 		        {
 		        }
-		        catch(Exception e) when(a)
-		        {
-		        }
+		        catch(Exception e) when(a) { }
 		    }
 		}
 		""",

--- a/tests/Nullean.Curb.Tests/Formatting/Statements/StatementTests.cs
+++ b/tests/Nullean.Curb.Tests/Formatting/Statements/StatementTests.cs
@@ -206,6 +206,163 @@ public class StatementTests : FormattingTest
 		}
 		""");
 
+	// ---- an empty catch or finally is always `{ }` ---------------------------------------------
+
+	/// <summary>
+	/// Curb's one unconditional opinion in this family: an empty <c>catch</c>/<c>finally</c> is
+	/// always <c>{ }</c>, whatever the source had and whatever the preserve options say. Unlike a
+	/// non-empty clause (below), this is <em>not</em> matching dotnet format — dotnet format is lazy
+	/// about this pair in both directions, so there is nothing of its to match, and <c>{ }</c> reads
+	/// better than the alternative either way.
+	/// See <see href="https://github.com/nullean/curb/issues/25">issue #25</see>.
+	/// </summary>
+	[Test]
+	public Task An_empty_catch_the_author_expanded_still_collapses() => Formats(
+		"""
+		public class C
+		{
+		    public void M()
+		    {
+		        try
+		        {
+		            Call();
+		        }
+		        catch
+		        {
+		        }
+		    }
+		}
+		""",
+		"""
+		public class C
+		{
+		    public void M()
+		    {
+		        try
+		        {
+		            Call();
+		        }
+		        catch { }
+		    }
+		}
+		""");
+
+	[Test]
+	public Task An_empty_finally_the_author_expanded_still_collapses() => Formats(
+		"""
+		public class C
+		{
+		    public void M()
+		    {
+		        try
+		        {
+		            Call();
+		        }
+		        finally
+		        {
+		        }
+		    }
+		}
+		""",
+		"""
+		public class C
+		{
+		    public void M()
+		    {
+		        try
+		        {
+		            Call();
+		        }
+		        finally { }
+		    }
+		}
+		""");
+
+	[Test]
+	public Task An_empty_catch_with_a_declaration_still_collapses() => Formats(
+		"""
+		public class C
+		{
+		    public void M()
+		    {
+		        try
+		        {
+		            Call();
+		        }
+		        catch (Exception e)
+		        {
+		        }
+		    }
+		}
+		""",
+		"""
+		public class C
+		{
+		    public void M()
+		    {
+		        try
+		        {
+		            Call();
+		        }
+		        catch (Exception e) { }
+		    }
+		}
+		""");
+
+	[Test]
+	public Task An_empty_catch_with_a_declaration_and_filter_still_collapses() => Formats(
+		"""
+		public class C
+		{
+		    public void M()
+		    {
+		        try
+		        {
+		            Call();
+		        }
+		        catch (IOException ex) when (ex.HResult != 0)
+		        {
+		        }
+		    }
+		}
+		""",
+		"""
+		public class C
+		{
+		    public void M()
+		    {
+		        try
+		        {
+		            Call();
+		        }
+		        catch (IOException ex) when (ex.HResult != 0) { }
+		    }
+		}
+		""");
+
+	[Test]
+	public Task An_empty_catch_stays_collapsed_with_both_preserve_options_off() => Unchanged(
+		"""
+		public class C
+		{
+		    public void M()
+		    {
+		        try
+		        {
+		            Call();
+		        }
+		        catch { }
+		    }
+		}
+		""",
+		editorConfig: """
+		csharp_preserve_single_line_blocks = false
+		csharp_preserve_single_line_statements = false
+		""");
+
+	// A non-empty catch or finally is untouched by this: PrintStatementBody's alwaysJoinsEmpty is
+	// ignored once the block is not empty, so behaviour there is exactly what it was before.
+
 	// ---- local declarations -------------------------------------------------------------------
 
 	[Test]


### PR DESCRIPTION
## Summary
- `dotnet format` is lazy about an empty `catch`/`finally` clause in **both** directions: it never joins one the author expanded (`catch\n{\n}`) and never expands one they joined (`catch { }`). Confirmed empirically both ways, even under fully default settings. So there's no dotnet-format behaviour to match here — whichever way Curb writes it, the next Format Document / IDE reformat leaves it alone.
- Given that, this makes the empty case Curb's own unconditional opinion: `catch { }`, `catch (Decl) { }`, `catch (Decl) when (Filter) { }`, `finally { }` — always, regardless of what the source had and regardless of `csharp_preserve_single_line_blocks` / `csharp_preserve_single_line_statements`. `csharp_empty_block_style` still wins when explicitly set, since that key is an explicit opinion about exactly this shape.
- A **non-empty** catch/finally body is untouched by this change — it keeps whatever `PrintStatementBody` already does for any other braced construct. (There's a separate, pre-existing gap where a non-empty catch/finally clause the author joined on one line can get split when the enclosing `try` body is already multi-line, under fully default settings — confirmed present on `origin/main` prior to this change too. Out of scope here; happy to file it separately if useful.)

## Implementation
`PrintStatementBody` gains an `alwaysJoinsEmpty` parameter, set only at the two catch/finally call sites in `PrintTryStatement`. It reuses the existing `JoinsEmptyBracesToHeader`-style flat/glue-to-header path, so an empty body's spacing matches whatever Curb already produces for every other collapsed empty block — verified there's no separate "empty braces" spacing rule to diverge from; `{ }` (one space) is an emergent property of `DocPrinter`'s hard-line-to-space collapse under flat mode, not a hardcoded literal.

## Test plan
- [x] Added coverage in `StatementTests.cs`: bare `catch`, `catch (Decl)`, `catch (Decl) when (Filter)`, and `finally`, all expanded in the source, all collapsing to `{ }`; plus both-preserve-options-off still collapsing.
- [x] Fixed a batch of pre-existing fixture tests (`csharp_new_line_before_catch`/`finally`, brace placement, parenthesis/keyword spacing) whose expected output used an expanded empty catch/finally as filler for an unrelated option — their expectations now reflect the always-collapsed shape.
- [x] `./build.sh test` — full suite passes (1109 total, 0 failed) both serially and in parallel.
- [x] Manually verified `csharp_empty_block_style = multiline` still forces an empty catch apart, and `csharp_preserve_single_line_blocks = false` no longer affects the empty case.

**Note (unrelated, pre-existing, confirmed on `origin/main` too):** `FingerprintTests.The_same_configuration_always_hashes_the_same` is flaky under parallel test execution (an `ArrayPool<string>.Shared` race in `Fingerprint.cs`). Not addressed here.

Fixes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q2uyojR4ARYNGcjezpt2Ry