### PR TITLE
Give collection expressions a leading-line bracket under reflow

### DIFF
--- a/src/Nullean.Curb.Core/Printing/CSharp/Printers.Expressions.cs
+++ b/src/Nullean.Curb.Core/Printing/CSharp/Printers.Expressions.cs
@@ -451,69 +451,98 @@ internal static partial class Printers
 	public static void CollectionExpression(CollectionExpressionSyntax node, PrintContext context)
 	{
 		var arena = context.Arena;
-		TokenPrinter.Print(node.OpenBracketToken, context);
 
-		if (node.Elements.Count > 0)
+		if (node.Elements.Count == 0)
 		{
-			var asWritten = SpansLines(node, context);
-			var rewritesComma = RewritesTrailingComma(node.Elements, node.CloseBracketToken, context);
+			TokenPrinter.Print(node.OpenBracketToken, context);
+			TokenPrinter.Print(node.CloseBracketToken, context);
+			return;
+		}
 
-			// Published for the same reason an initializer's is: `new C([…]) { X = 1 }` hands the list no
-			// group to break, so the trailing initializer aims at this one instead.
-			var group = arena.NextGroupId();
-			context.OwnBlockGroup = group;
+		var asWritten = SpansLines(node, context);
+		var rewritesComma = RewritesTrailingComma(node.Elements, node.CloseBracketToken, context);
 
-			using (arena.Group(group))
+		// Published for the same reason an initializer's is: `new C([…]) { X = 1 }` hands the list no
+		// group to break, so the trailing initializer aims at this one instead.
+		var group = arena.NextGroupId();
+		context.OwnBlockGroup = group;
+
+		using (arena.Group(group))
+		{
+			// A collection expression is the third spelling of a collection initializer, so it answers
+			// to the same key. Deterministic mode only; see FormatOptions.
+			if (context.Options.WrapObjectAndCollectionInitializerStyle == WrapStyle.ChopAlways)
+				arena.BreakParent();
+
+			// Only for the value of an assignment or declarator — `int[] values = [...]` — where the
+			// bracket has somewhere else to go. A nested element (`[[1, 2], [3, 4]]`) or an argument
+			// (`Call([1, 2])`) is already positioned by its own container, and giving it a leading
+			// line of its own would put it a level out from what dotnet format produces, exactly as
+			// InitializerExpression's leadingLine is only ever true for the same kind of position.
+			//
+			// Soft, not the brace helpers' Normal line: EqualsValueClause and OperandOnRight already
+			// print the space that belongs here when this stays flat, so only the broken case needs
+			// anything from this line at all — a Normal line would double that space.
+			if (node.Parent is EqualsValueClauseSyntax or AssignmentExpressionSyntax
+				&& context.Options.NewLineBeforeOpenBrace.HasFlag(BraceStyle.ObjectCollectionArrayInitializers))
 			{
-				// A collection expression is the third spelling of a collection initializer, so it answers
-				// to the same key. Deterministic mode only; see FormatOptions.
-				if (context.Options.WrapObjectAndCollectionInitializerStyle == WrapStyle.ChopAlways)
-					arena.BreakParent();
-
-				using (arena.Indent())
+				using (arena.IndentIf(context.Options.IndentBraces))
 				{
-					Edge(node.SpanStart, node.Elements[0].SpanStart);
-					for (var i = 0; i < node.Elements.Count; i++)
-					{
-						Node.Print(node.Elements[i], context);
-						if (i >= node.Elements.SeparatorCount)
-							continue;
+					// The author already broke before this bracket — keep it, the same as
+					// InitializerExpression's own asWritten-broke branch, so preservation mode does
+					// not silently join what the author split across lines.
+					if (asWritten && context.AuthorBroke(node.Parent.SpanStart, node.SpanStart))
+						arena.HardLine();
+					else
+						arena.SoftLine(DocFlags.OnlyIfNotAtLineStart);
+				}
+			}
 
-						if (rewritesComma && i == node.Elements.Count - 1)
-							continue;
+			TokenPrinter.Print(node.OpenBracketToken, context);
 
-						Spacing.BeforeComma(context);
-						TokenPrinter.Print(node.Elements.GetSeparator(i), context);
+			using (arena.Indent())
+			{
+				Edge(node.SpanStart, node.Elements[0].SpanStart);
+				for (var i = 0; i < node.Elements.Count; i++)
+				{
+					Node.Print(node.Elements[i], context);
+					if (i >= node.Elements.SeparatorCount)
+						continue;
 
-						// A trailing comma runs straight into the closing bracket, not `, ]`.
-						if (i >= node.Elements.Count - 1)
-							continue;
+					if (rewritesComma && i == node.Elements.Count - 1)
+						continue;
 
-						if (!asWritten)
-							Spacing.AfterCommaBreakable(context);
-						else if (context.AuthorJoined(node.Elements[i].Span.End, node.Elements[i + 1].SpanStart))
-							Spacing.AfterComma(context);
-						else
-							arena.HardLine();
-					}
+					Spacing.BeforeComma(context);
+					TokenPrinter.Print(node.Elements.GetSeparator(i), context);
 
-					if (rewritesComma)
-						PrintTrailingComma(context);
+					// A trailing comma runs straight into the closing bracket, not `, ]`.
+					if (i >= node.Elements.Count - 1)
+						continue;
+
+					if (!asWritten)
+						Spacing.AfterCommaBreakable(context);
+					else if (context.AuthorJoined(node.Elements[i].Span.End, node.Elements[i + 1].SpanStart))
+						Spacing.AfterComma(context);
+					else
+						arena.HardLine();
 				}
 
-				Edge(node.Elements[^1].Span.End, node.Span.End);
+				if (rewritesComma)
+					PrintTrailingComma(context);
 			}
 
-			void Edge(int from, int to)
-			{
-				if (asWritten && context.AuthorBroke(from, to))
-					arena.HardLine();
-				else
-					Spacing.InsideBracketsBreakable(context);
-			}
+			Edge(node.Elements[^1].Span.End, node.Span.End);
 		}
 
 		TokenPrinter.Print(node.CloseBracketToken, context);
+
+		void Edge(int from, int to)
+		{
+			if (asWritten && context.AuthorBroke(from, to))
+				arena.HardLine();
+			else
+				Spacing.InsideBracketsBreakable(context);
+		}
 	}
 
 	public static void SimpleLambdaExpression(SimpleLambdaExpressionSyntax node, PrintContext context)

--- a/tests/Nullean.Curb.Tests/Formatting/Expressions/InitializerTests.cs
+++ b/tests/Nullean.Curb.Tests/Formatting/Expressions/InitializerTests.cs
@@ -212,6 +212,34 @@ public class InitializerTests : FormattingTest
 		""");
 
 	[Test]
+	public Task An_author_broken_collection_expression_keeps_its_bracket_on_its_own_line() => Unchanged(
+		"""
+		public class C
+		{
+		    public void M()
+		    {
+		        int[] values =
+		        [
+		            alpha,
+		            beta,
+		        ];
+		    }
+		}
+		""");
+
+	[Test]
+	public Task A_reassigned_collection_expression_keeps_its_bracket_hugged_when_it_fits() => Unchanged(
+		"""
+		public class C
+		{
+		    public void M(int[] values)
+		    {
+		        values = [alpha, beta];
+		    }
+		}
+		""");
+
+	[Test]
 	public Task Anonymous_object() => Unchanged(
 		"""
 		public class C

--- a/tests/Nullean.Curb.Tests/Formatting/Expressions/ReflowTests.cs
+++ b/tests/Nullean.Curb.Tests/Formatting/Expressions/ReflowTests.cs
@@ -72,7 +72,6 @@ public class ReflowTests : FormattingTest
 		editorConfig: "max_line_length = 30");
 
 	[Test]
-	[Skip("the value breaks after `=` and the bracket double-indents; same gap as query clauses")]
 	public Task Collection_expression_breaks_one_per_line() => Formats(
 		"""
 		public class C
@@ -89,6 +88,35 @@ public class ReflowTests : FormattingTest
 		    public void M()
 		    {
 		        int[] values =
+		        [
+		            alpha,
+		            beta,
+		            gamma
+		        ];
+		    }
+		}
+		""",
+		editorConfig: "max_line_length = 30");
+
+	[Test]
+	public Task A_reassigned_collection_expression_breaks_the_same_way() => Formats(
+		"""
+		public class C
+		{
+		    public void M()
+		    {
+		        int[] values;
+		        values = [alpha, beta, gamma];
+		    }
+		}
+		""",
+		"""
+		public class C
+		{
+		    public void M()
+		    {
+		        int[] values;
+		        values =
 		        [
 		            alpha,
 		            beta,

--- a/tests/Nullean.Curb.Tests/Formatting/Options/SquareBracketSpacingTests.cs
+++ b/tests/Nullean.Curb.Tests/Formatting/Options/SquareBracketSpacingTests.cs
@@ -331,7 +331,8 @@ public class SquareBracketSpacingTests : FormattingTest
 		{
 		    public void M()
 		    {
-		        int[] e = [
+		        int[] e =
+		        [
 		            firstElement,
 		            secondElement,
 		            thirdElement


### PR DESCRIPTION
## Summary
- `Printers.CollectionExpression` printed its `[` unconditionally hugging whatever came before it. `Printers.InitializerExpression` (`new Thing { ... }`) already has a `leadingLine` mechanism that moves `{` to its own line when reflow forces a break, or when the author already wrote it that way — collection expressions (`[...]`, C# 12) never got the same treatment because they're a completely separate printer.
- Fix: when a collection expression is the value of a declarator or a plain reassignment (`node.Parent is EqualsValueClauseSyntax or AssignmentExpressionSyntax`), it now offers a line before `[`, inside the *same* group as its own elements — so it breaks in sync with them automatically, no cross-group bookkeeping needed. Nested elements (`[[1,2],[3,4]]`) and call arguments (`Call([1,2])`) are unaffected since their parent doesn't match.
- Used `SoftLine` rather than the existing brace helpers' `Line` (Normal): `EqualsValueClause`/`OperandOnRight` already print the flat-case space before delegating to the value's printer, so a Normal line would have doubled it (`=  [`). Soft renders as nothing when flat and a newline when broken, avoiding that without touching either caller.
- An author-written break before `[` is now preserved outside reflow too, mirroring `InitializerExpression`'s own preservation branch — this fixes a **second, previously-untracked bug** found while testing: `values =\n[\n  a,\n];` was silently collapsed onto one line even with reflow off, unlike every other own-block construct.

## Test plan
- [x] Un-skipped `ReflowTests.Collection_expression_breaks_one_per_line` (the target)
- [x] Added `ReflowTests.A_reassigned_collection_expression_breaks_the_same_way` — covers the `AssignmentExpression`/`OperandOnRight` path, not just declaration
- [x] Added `InitializerTests.An_author_broken_collection_expression_keeps_its_bracket_on_its_own_line` — locks in the preservation-mode fix
- [x] Added `InitializerTests.A_reassigned_collection_expression_keeps_its_bracket_hugged_when_it_fits` — confirms no leading line when it isn't needed
- [x] Verified no double-space regression under `csharp_space_around_binary_operators = none`
- [x] Updated `SquareBracketSpacingTests.Inner_spacing_does_not_stop_a_collection_from_wrapping`, whose fixture had encoded the old hugging bug as its expectation
- [x] `Nested_collection_expressions`, `Collection_expression`, `Empty_collection_expression`, `Spread_element_keeps_its_space` all still pass unchanged
- [x] `./build.sh test` — 1087 passed, 0 failed, 10 skips (unrelated)
- [x] `curb check` over Curb's own `src`/`tests`/`tools` shows zero delta vs. main (same 57 pre-existing would-change files both before and after this change)

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)