### PR TITLE
Remove stale mixed-line-endings limitation from docs

### DIFF
--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -5,16 +5,6 @@ description: Current limitations in Curb's formatting output and what to expect 
 
 # Known limitations
 
-## Multi-line trivia keeps source line endings
-
-{{product}} emits multi-line trivia — doc comments, verbatim string literals — as a raw source span,
-so their internal newlines survive unchanged while the breaks {{product}} emits itself use the configured
-line ending. The result is a file with mixed line endings.
-
-This means `dotnet format` disagrees with {{product}}'s output on any file containing doc comments
-whose source line endings differ from the configured `end_of_line`. It is the most common source of
-fixed-point failures in the [twelve-repository comparison](benchmarks/index.md).
-
 ## Expression-body conversions do not compose in one pass
 
 With both `csharp_style_expression_bodied_properties = true` and


### PR DESCRIPTION
## Summary
Investigated #14 after a request to confirm comments get `end_of_line` normalization. Turns out this is already fully implemented on `main` — the docs just never caught up.

- `TokenPrinter.EmitSourceLines` already splits a multi-line comment's internal `\r\n`/`\n` and re-issues each as a `LiteralLine`, which `DocPrinter` renders through the configured `end_of_line` rather than copying it verbatim from source.
- There's already a passing test proving it: `DocumentationCommentTests.A_doc_comment_takes_the_configured_line_ending`. Its own comment cites the real-world impact this fixed (efcore 3,189 fixed points, log4net 322).
- I additionally verified manually (CRLF source, `end_of_line = lf`) that both `///` doc comments and `/* */` block comments get every internal line ending normalized correctly.
- Verbatim string literal content is, correctly, left untouched — normalizing `\r\n` inside a verbatim string's content would change the compiled string's *value*, not just its formatting. That was never a bug; the doc just lumped it in with the comment case.

Removed the now-stale "Multi-line trivia keeps source line endings" section from `docs/known-limitations.md`.

Closes #14

## Test plan
- [x] `DocumentationCommentTests` — 12 passed, 0 failed (includes the exact scenario this issue described)
- [x] Manually verified CRLF→LF normalization inside both `///` and `/* */` multi-line comments
- [x] Manually verified verbatim string literal content (`@"line1\r\nline2"`) is correctly left untouched while surrounding code layout is normalized
- [x] `./build.sh test` — full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)