### PR TITLE
Docs: remove stale expression-body compose-in-one-pass limitation

### DIFF
--- a/docs/benchmarks/churn.md
+++ b/docs/benchmarks/churn.md
@@ -98,7 +98,7 @@ The first-run churn is ground `dotnet format` doesn't cover:
 - Chain breaking
 - Comment alignment
 - Reflow to `max_line_length` (only if set — see below)
-- BOM handling (see [known limitations](../known-limitations.md) for the current caveat)
+- BOM handling
 
 ## Reducing churn on adoption
 

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -15,22 +15,6 @@ This means `dotnet format` disagrees with {{product}}'s output on any file conta
 whose source line endings differ from the configured `end_of_line`. It is the most common source of
 fixed-point failures in the [twelve-repository comparison](benchmarks/index.md).
 
-## Expression-body conversions do not compose in one pass
-
-With both `csharp_style_expression_bodied_properties = true` and
-`csharp_style_expression_bodied_accessors = true`, the two conversions can produce different output
-on consecutive passes:
-
-```csharp
-public int Count { get { throw new NotImplementedException(); } }   // source
-public int Count { get => throw new NotImplementedException(); }    // run 1
-public int Count => throw new NotImplementedException();            // run 2 — different
-```
-
-The accessor-level conversion fires on run 1. The property-level conversion only recognises an
-accessor list that already has an arrow getter, so it fires on run 2. Two rules that should compose
-in one pass currently do not.
-
 ## Anchor columns feed back into the next run
 
 In certain initializer patterns, {{product}}'s output indentation can change between consecutive


### PR DESCRIPTION
## Summary
- Removes the "Expression-body conversions do not compose in one pass" section from `docs/known-limitations.md`.
- The limitation it describes was fixed by commit `2d326b1` ("Collapse a throwing getter in one pass", 2026-08-17) — `TryPrintExpressionProperty` recognizes a throwing getter's block directly from the original syntax tree (alongside the existing returning-block and arrow-getter cases), so the property-level `=>` collapse and the accessor-level `=>` collapse already compose in a single run. The docs restructure the following day carried the limitation section forward verbatim instead of dropping it once the fix landed.
- Verified: `A_throwing_getter_collapses_in_one_pass` in `tests/Nullean.Curb.Tests/Formatting/Options/ExpressionBodyTests.cs` covers the exact scenario from the (now closed) issue and passes, and the test harness's fixed-point check (every `Formats`/`Unchanged` test formats twice and asserts equality) confirms it settles in one pass.
- Closes #15 (already closed directly with the research written into the issue comment).
- Also drops a dangling link in `docs/benchmarks/churn.md`'s "BOM handling" bullet, which pointed at the known-limitations caveat that #33 already removed. The bullet itself stays — BOM handling is still a churn source, just no longer a broken pointer.

## Test plan
- [x] Confirmed no other doc references the removed section's anchor (`docs/_docset.yml` and `docs/benchmarks/churn.md` both link the whole `known-limitations.md` page, not the specific heading)
- [x] `A_throwing_getter_collapses_in_one_pass` passes on `main` today

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015byCT9ghPLnCK3QZf5wNPD