### PR TITLE
Fix ternary indenting twice when assigned under reflow

### DIFF
--- a/src/Nullean.Curb.Core/Printing/CSharp/Printers.Declarations.cs
+++ b/src/Nullean.Curb.Core/Printing/CSharp/Printers.Declarations.cs
@@ -140,7 +140,11 @@ internal static partial class Printers
 			or ConditionalAccessExpressionSyntax
 			or BinaryExpressionSyntax
 			or ObjectCreationExpressionSyntax
-			or ImplicitObjectCreationExpressionSyntax;
+			or ImplicitObjectCreationExpressionSyntax
+			// A ternary breaks at its own ? and :, one indent in from wherever it starts. Breaking
+			// after the = as well nests those a level deeper than the assignment they belong to —
+			// issue #34.
+			or ConditionalExpressionSyntax;
 
 	/// <summary>True for values whose own layout supplies the indentation of their contents.</summary>
 	internal static bool BringsOwnBlock(ExpressionSyntax? value) =>

--- a/src/Nullean.Curb.Core/Printing/CSharp/Printers.Expressions.cs
+++ b/src/Nullean.Curb.Core/Printing/CSharp/Printers.Expressions.cs
@@ -51,9 +51,19 @@ internal static partial class Printers
 
 		// Where the operand starts, not whether it spans lines — see EqualsValueClause for why the
 		// difference decides whether formatting twice settles.
+		//
+		// A ternary breaks at its own ? and :, one indent in from wherever it starts, so it needs no
+		// hanging indent here either — the same reasoning EqualsValueClause's BreaksWithoutHelp
+		// applies to a declarator's initializer, for the plain-assignment case (issue #34). Scoped to
+		// the ternary alone rather than reusing that whole list: precedence keeps every other member
+		// of it out of reach of an operator's right operand without parentheses (`a && b.Foo()`'s
+		// right side is real and would need its own measurement), but `a ? b : c` binds looser than
+		// every binary operator, so an unparenthesized ternary can only ever land here as an
+		// assignment's RHS.
 		if (right is ExpressionSyntax expression
 			&& (BringsOwnBlock(expression)
-				|| (operatorEnd >= 0 && context.AuthorJoined(operatorEnd, expression.SpanStart))))
+				|| (operatorEnd >= 0 && context.AuthorJoined(operatorEnd, expression.SpanStart))
+				|| (!context.Options.KeepExistingLinebreaks && expression is ConditionalExpressionSyntax)))
 		{
 			Spacing.BeforeOperator(context);
 			Node.Print(right, context);

--- a/tests/Nullean.Curb.Tests/Formatting/Expressions/ReflowTests.cs
+++ b/tests/Nullean.Curb.Tests/Formatting/Expressions/ReflowTests.cs
@@ -127,6 +127,63 @@ public class ReflowTests : FormattingTest
 		""",
 		editorConfig: "max_line_length = 30");
 
+	/// <summary>
+	/// A ternary breaks at its own <c>?</c> and <c>:</c>, one indent in from wherever it starts. Curb
+	/// used to break after the <c>=</c> as well, nesting those a level deeper than the assignment
+	/// they belong to. See <see href="https://github.com/nullean/curb/issues/34">issue #34</see>.
+	/// </summary>
+	[Test]
+	public Task A_ternary_initializer_indents_once_not_twice() => Formats(
+		"""
+		public class C
+		{
+		    public void M(bool condition)
+		    {
+		        var value = condition ? alpha : beta;
+		    }
+		}
+		""",
+		"""
+		public class C
+		{
+		    public void M(bool condition)
+		    {
+		        var value = condition
+		            ? alpha
+		            : beta;
+		    }
+		}
+		""",
+		editorConfig: "max_line_length = 40");
+
+	[Test]
+	public Task A_ternary_reassignment_indents_once_not_twice() => Formats(
+		"""
+		public class C
+		{
+		    private object value;
+
+		    public void M(bool condition)
+		    {
+		        value = condition ? alpha : beta;
+		    }
+		}
+		""",
+		"""
+		public class C
+		{
+		    private object value;
+
+		    public void M(bool condition)
+		    {
+		        value = condition
+		            ? alpha
+		            : beta;
+		    }
+		}
+		""",
+		editorConfig: "max_line_length = 40");
+
 	[Test]
 	public Task Nested_calls_break_from_the_outside_in() => Formats(
 		"""


### PR DESCRIPTION
## Summary
- When a ternary assigned to a variable breaks under `max_line_length`, Curb was breaking after the `=` as well as at the ternary's own `?`/`:`, nesting the condition one level too deep and `?`/`:` two levels deep instead of one.
- A ternary has break points of its own (`?` and `:`), so it belongs in the same "breaks without help" family as a call, a member chain, or a binary chain — constructs `EqualsValueClause` (the `var x = ...` initializer printer) already knows not to add a redundant hanging indent for. It was simply missing from that switch (`BreaksWithoutHelp` in `Printers.Declarations.cs`).
- The issue's second example is a plain reassignment (`x = ternary;`, not a declaration), which goes through a separate path — `OperandOnRight` in `Printers.Expressions.cs`, shared with `BinaryExpression`'s right operand — that had no equivalent check at all. Added one scoped specifically to `ConditionalExpressionSyntax` rather than reusing `EqualsValueClause`'s whole allow-list: precedence means a ternary can only ever reach an operator's right operand unparenthesized via assignment (`?:` binds looser than every binary operator, so `a && b ? c : d` parses with the ternary outermost, not as `a && (b ? c : d)`) — the other members of that list (a call, a member access) are real, common right operands of binary expressions and would need their own separate measurement to touch safely.
- Both changes are gated to deterministic mode only (`!KeepExistingLinebreaks`), matching the existing pattern: in preservation mode there's an author to ask, and `AuthorJoined` already covers a value that started on the `=` line.

## Test plan
- [x] Added `A_ternary_initializer_indents_once_not_twice` and `A_ternary_reassignment_indents_once_not_twice` to `ReflowTests.cs`
- [x] `./build.sh test` — full suite passes (1135 total, 0 failed)
- [x] Manually verified against both of the issue's exact repro shapes (declaration and reassignment) with the CLI, including idempotency (`format(format(x)) == format(x)`) and that a short ternary still collapses to one line when it fits

Fixes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q2uyojR4ARYNGcjezpt2Ry