### PR TITLE
Normalise a two-operand chain's operator side under wrap_chained_binary_expressions

### DIFF
--- a/src/Nullean.Curb.Core/Printing/CSharp/Printers.BinaryChains.cs
+++ b/src/Nullean.Curb.Core/Printing/CSharp/Printers.BinaryChains.cs
@@ -48,12 +48,18 @@ internal static partial class Printers
 		if (node.Parent is BinaryExpressionSyntax parent && parent.OperatorToken.RawKind == node.OperatorToken.RawKind)
 			return false;
 
-		// Two operands read fine on one line and have a break opportunity from the group anyway.
 		var operands = new List<ExpressionSyntax>();
 		var operators = new List<SyntaxToken>();
 		Flatten(node, operands, operators);
 
-		if (operands.Count < 3)
+		// A two-operand chain used to fall through to the ordinary per-operator path instead, on the
+		// reasoning that it reads fine on one line and the group there already offers a break. It
+		// does, but that path never reads csharp_wrap_before_binary_opsign — it only ever reproduces
+		// whichever side the author already broke on, which left a two-operand chain unable to have
+		// its operator normalised at all once csharp_wrap_chained_binary_expressions asked for it
+		// (issue #46). A genuine BinaryExpressionSyntax always flattens to at least two operands, so
+		// this is defensive rather than a real exclusion.
+		if (operands.Count < 2)
 			return false;
 
 		var arena = context.Arena;

--- a/tests/Nullean.Curb.Tests/Formatting/Options/ClosingParenthesisTests.cs
+++ b/tests/Nullean.Curb.Tests/Formatting/Options/ClosingParenthesisTests.cs
@@ -516,7 +516,7 @@ public class ClosingParenthesisTests : FormattingTest
 
 	[Test]
 	public Task A_two_operand_chain_is_left_alone() => Unchanged(
-		// Two reads fine on one line, and the group around it already offers a break.
+		// Two operands read fine on one line; chop_if_long only breaks once it doesn't fit.
 		"""
 		public class C
 		{
@@ -527,6 +527,65 @@ public class ClosingParenthesisTests : FormattingTest
 		}
 		""",
 		editorConfig: Narrow + "\ncsharp_wrap_chained_binary_expressions = chop_if_long");
+
+	/// <summary>
+	/// A two-operand chain goes through this printer too now, not just three or more — it used to
+	/// fall through to the ordinary per-operator path, which never reads
+	/// <c>csharp_wrap_before_binary_opsign</c> and only ever reproduces whichever side the author
+	/// already broke on. That left a two-operand chain unable to have its operator normalised at all
+	/// once <c>csharp_wrap_chained_binary_expressions</c> asked for it — regardless of whether the
+	/// break was already there (from <c>dotnet format style</c>, say) or one this run introduced.
+	/// See <see href="https://github.com/nullean/curb/issues/46">issue #46</see>.
+	/// </summary>
+	[Test]
+	public Task A_two_operand_chain_still_normalises_the_operator_side() => Formats(
+		"""
+		public class C
+		{
+		    public void M()
+		    {
+		        var ok = alphaConditionLong &&
+		            betaConditionLong;
+		    }
+		}
+		""",
+		"""
+		public class C
+		{
+		    public void M()
+		    {
+		        var ok = alphaConditionLong
+		            && betaConditionLong;
+		    }
+		}
+		""",
+		editorConfig: "max_line_length = 20\ncsharp_wrap_chained_binary_expressions = chop_if_long");
+
+	[Test]
+	public Task A_two_operand_chain_can_keep_the_operator_trailing_instead() => Formats(
+		"""
+		public class C
+		{
+		    public void M()
+		    {
+		        var ok = alphaConditionLong
+		            && betaConditionLong;
+		    }
+		}
+		""",
+		"""
+		public class C
+		{
+		    public void M()
+		    {
+		        var ok = alphaConditionLong &&
+		            betaConditionLong;
+		    }
+		}
+		""",
+		editorConfig: "max_line_length = 20"
+			+ "\ncsharp_wrap_chained_binary_expressions = chop_if_long"
+			+ "\ncsharp_wrap_before_binary_opsign = false");
 
 	[Test]
 	public Task A_right_associative_chain_keeps_every_operator() => Formats(


### PR DESCRIPTION
## Summary
- `csharp_wrap_before_binary_opsign` only ever took effect once `TryPrintBinaryChain` was already breaking a chain of **three or more** operands. A two-operand chain (`a && b`) fell through to the ordinary per-operator `BinaryExpression` path instead, which has no notion of the option at all — it only ever reproduces whichever side the author (or `dotnet format style`) already broke the line on. So a two-operand chain could never have its operator normalised, regardless of whether the break already existed in the source or this run introduced it.
- This is a **narrower** fix than the issue's literal expected-behaviour section: it only takes effect when `csharp_wrap_chained_binary_expressions` is also set. I confirmed the option is documented and gated as deterministic-mode-and-chain-wrap-only by design ("only consulted once a chain is being broken at all" — `FormatOptions.cs`), and unconditionally normalising *any* binary-operator line break (the issue's literal repro doesn't show `wrap_chained_binary_expressions` being set) would touch the default printer path used by nearly all binary expressions in any C# file — real corpus measurement I can't do in this environment. Went with the narrow scope after checking in.
- Mechanically: `TryPrintBinaryChain`'s operand-count guard dropped from `< 3` to `< 2` — a genuine `BinaryExpressionSyntax` always flattens to at least 2 operands, so this just removes an exclusion that existed for the two-operand case specifically. Everything downstream of that guard (the `Group`/`Fill`, `PrintOperator`'s `WrapBeforeBinaryOpsign` check, `chop_if_long`/`chop_always`) already worked correctly for 3+ operands and now applies uniformly.
- The far more common default path — no `wrap_chained_binary_expressions` key at all — is untouched.

## Test plan
- [x] Updated the stale comment on the pre-existing `A_two_operand_chain_is_left_alone` test (it was never really "excluded," it just fits under the width)
- [x] Added `A_two_operand_chain_still_normalises_the_operator_side` and `A_two_operand_chain_can_keep_the_operator_trailing_instead` to `ClosingParenthesisTests.cs`
- [x] `./build.sh test` — full suite passes (1137 total, 0 failed)
- [x] Manually verified against the issue's exact repro shape (with `max_line_length` and `csharp_wrap_chained_binary_expressions` also set, since the fix is scoped to that path) — the trailing `&&` from a `dotnet format style`-produced file now normalises to leading

Fixes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q2uyojR4ARYNGcjezpt2Ry