### PR TITLE
Attach CURB0001 to the unformatted file, not the project

### DIFF
--- a/docs/workflow/msbuild.md
+++ b/docs/workflow/msbuild.md
@@ -64,12 +64,13 @@ dotnet build -p:Curb_Check=true               # check without rewriting
 | `Curb_Cache` | `true` | Reuse the previous run's verdict for files that have not changed. Set `false` to build without a cache. |
 | `Curb_CacheFile` | `$(IntermediateOutputPath)curb.cache` | Where that cache lives. |
 | `Curb_FileList` | `$(IntermediateOutputPath)curb.files` | The compile set handed to the CLI. |
+| `Curb_UnformattedFile` | `$(IntermediateOutputPath)curb.unformatted` | The paths `check` reports back as unformatted, one per line — what the target reads to attach CURB0001 to each of them. |
 
 ## Diagnostics
 
 | Code | Severity | Meaning |
 |---|---|---|
-| `CURB0001` | error, or warning with `Curb_UnformattedAsWarnings` | Some files are not formatted. Only `check` can produce this. |
+| `CURB0001` | error, or warning with `Curb_UnformattedAsWarnings` | A file is not formatted. Only `check` can produce this, and it is raised once per unformatted file, attached to that file — not to the project — so a GitHub Actions annotation names the file a reviewer needs to look at. |
 | `CURB0002` | error, always | {{product}} itself failed. This is an error whatever the warnings setting says — a formatter that could not run has verified nothing, and saying so quietly would be worse than not running at all. |
 
 ## How incrementality works

--- a/src/Nullean.Curb.Cli/CurbCommands.cs
+++ b/src/Nullean.Curb.Cli/CurbCommands.cs
@@ -49,6 +49,10 @@ internal sealed class CurbCommands
 	/// <param name="noVerify">Skip re-parsing output to prove the token stream is unchanged.</param>
 	/// <param name="expandUnhandled">Benchmark-only cost model: pretend every syntax kind has a dedicated printer.</param>
 	/// <param name="coverage">Report which syntax kinds are still emitted verbatim.</param>
+	/// <param name="unformattedListFile">
+	/// Write the paths that would change to this file, one per line. What the MSBuild integration reads
+	/// back to attach CURB0001 to each unformatted file instead of to the project.
+	/// </param>
 	public int Check(
 		[Argument] string path = ".",
 		List<FileInfo>? files = null,
@@ -56,7 +60,8 @@ internal sealed class CurbCommands
 		string? cache = null,
 		bool noVerify = false,
 		bool expandUnhandled = false,
-		bool coverage = false
+		bool coverage = false,
+		FileInfo? unformattedListFile = null
 	) =>
 		FormattingRun.Execute(
 			_fileSystem,
@@ -66,7 +71,8 @@ internal sealed class CurbCommands
 			verify: !noVerify,
 			coverageReport: coverage,
 			explicitFiles: ResolveExplicitFiles(files, msbuildListFile),
-			cachePath: cache
+			cachePath: cache,
+			unformattedListPath: unformattedListFile?.FullName
 		).ExitCode;
 
 	/// <summary>

--- a/src/Nullean.Curb.Cli/FormattingRun.cs
+++ b/src/Nullean.Curb.Cli/FormattingRun.cs
@@ -50,6 +50,12 @@ internal static class FormattingRun
 	/// Where to remember which files were already formatted, so a run triggered by one changed file does
 	/// not re-parse the rest. Absent means no cache: the caller names the path or there is not one.
 	/// </param>
+	/// <param name="unformattedListPath">
+	/// Where to write the paths of files that would change, one per line, sorted. What the MSBuild
+	/// integration reads back after a failed <c>check</c>, so it can attach the CURB0001 diagnostic to
+	/// each file that actually needs reformatting instead of to the project. Ignored when <paramref
+	/// name="write"/> is <see langword="true"/>: a format run leaves nothing unformatted to list.
+	/// </param>
 	public static FormattingRunSummary Execute(
 		IFileSystem fileSystem,
 		string target,
@@ -58,7 +64,8 @@ internal static class FormattingRun
 		bool? verify = null,
 		bool coverageReport = false,
 		string[]? explicitFiles = null,
-		string? cachePath = null)
+		string? cachePath = null,
+		string? unformattedListPath = null)
 	{
 		// On by default for both commands: the printer tracks whether it actually put a token
 		// boundary at risk, so on code that does not, the second parse never happens.
@@ -124,6 +131,7 @@ internal static class FormattingRun
 		var reparsed = 0;
 		var unhandled = new Dictionary<int, int>();
 		var messages = new System.Collections.Concurrent.ConcurrentBag<string>();
+		var unformatted = write || unformattedListPath is null ? null : new System.Collections.Concurrent.ConcurrentBag<string>();
 
 		var allocatedBefore = GC.GetTotalAllocatedBytes(precise: true);
 		var stopwatch = Stopwatch.StartNew();
@@ -246,6 +254,8 @@ internal static class FormattingRun
 										item.Path,
 										result.Text ?? source,
 										wantsBom ? Utf8WithBom : Utf8);
+								else
+									unformatted?.Add(item.Path);
 								Interlocked.Increment(ref changed);
 							}
 							else
@@ -301,6 +311,12 @@ internal static class FormattingRun
 		// that fail: a check that finds an unformatted file never stamps, so the build repeats it until
 		// somebody formats the file, and the cache is what makes those repeats cost one file.
 		cache?.Save();
+
+		// Sorted for the same reason the messages below are: a ConcurrentBag's order is whichever
+		// worker finished last, and the MSBuild target that reads this back turns each line into a
+		// diagnostic — a build log that reorders itself between runs is worse than an unsorted one.
+		if (unformattedListPath is not null)
+			fileSystem.File.WriteAllLines(unformattedListPath, (unformatted ?? []).OrderBy(p => p, StringComparer.Ordinal));
 
 		// Sorted, because a ConcurrentBag hands them back in whatever order the threads finished, so
 		// two runs over the same tree reported a different arbitrary twenty. Diagnosing a large

--- a/src/Nullean.Curb.MSBuild/build/curb.targets
+++ b/src/Nullean.Curb.MSBuild/build/curb.targets
@@ -92,6 +92,11 @@
       <Curb_StampFile Condition="'$(Curb_StampFile)' == ''">$(IntermediateOutputPath)curb.stamp</Curb_StampFile>
       <Curb_FileList Condition="'$(Curb_FileList)' == ''">$(IntermediateOutputPath)curb.files</Curb_FileList>
 
+      <!-- Where `check` writes back the paths that would change, so the CURB0001 diagnostic below can
+           be attached to each of them instead of to the project. Only `check` ever writes it; `format`
+           leaves nothing unformatted to list. -->
+      <Curb_UnformattedFile Condition="'$(Curb_UnformattedFile)' == ''">$(IntermediateOutputPath)curb.unformatted</Curb_UnformattedFile>
+
       <!-- Per file rather than per project; see the note in the Curb target for what that buys. Here for
            the same reason as the other two, and per target framework for the same reason as the error
            log, so two inner builds of a multi-targeting project cannot write over each other. Set
@@ -155,24 +160,50 @@
       <_CurbInvocation Condition="'$(Curb_Exe)' != ''">&quot;$(Curb_Exe)&quot;</_CurbInvocation>
       <_CurbInvocation Condition="'$(Curb_Exe)' == ''">&quot;$(DOTNET_HOST_PATH)&quot; &quot;$(Curb_Dll)&quot;</_CurbInvocation>
       <_CurbCacheArg Condition="'$(Curb_Cache)' != 'false' and '$(Curb_CacheFile)' != ''">--cache &quot;$(Curb_CacheFile)&quot;</_CurbCacheArg>
+
+      <!-- Only `check` reads this back; a `format` run leaves nothing unformatted to name. -->
+      <_CurbUnformattedArg Condition="'$(_CurbCommand)' == 'check'">--unformatted-list-file &quot;$(Curb_UnformattedFile)&quot;</_CurbUnformattedArg>
     </PropertyGroup>
 
-    <Exec Command="$(_CurbInvocation) $(_CurbCommand) --msbuild-list-file &quot;$(Curb_FileList)&quot; $(_CurbCacheArg)"
+    <Exec Command="$(_CurbInvocation) $(_CurbCommand) --msbuild-list-file &quot;$(Curb_FileList)&quot; $(_CurbCacheArg) $(_CurbUnformattedArg)"
           StandardOutputImportance="$(Curb_LogLevel)"
           ContinueOnError="true"
           IgnoreExitCode="true">
       <Output TaskParameter="ExitCode" PropertyName="_CurbExitCode" />
     </Exec>
 
+    <!-- The file `check` wrote back, one unformatted path per line, so each diagnostic below lands on
+         the source file that actually needs reformatting instead of on this project — that is what a
+         GitHub Actions annotation anchors to, and $(MSBuildProjectFullPath) with no line number was
+         never actionable from the PR checks panel alone. -->
+    <ReadLinesFromFile File="$(Curb_UnformattedFile)" Condition="'$(_CurbExitCode)' == '1' and Exists('$(Curb_UnformattedFile)')">
+      <Output TaskParameter="Lines" ItemName="_CurbUnformattedFiles" />
+    </ReadLinesFromFile>
+
     <!-- Exit 1 is "some files are not formatted", which only `check` can produce. Anything else
          non-zero is Curb failing, and that is an error whatever the warnings setting says: a
          formatter that could not run has verified nothing, and saying so quietly would be worse
-         than not running at all. -->
-    <Warning Condition="'$(_CurbExitCode)' == '1' and '$(Curb_UnformattedAsWarnings)' == 'true'"
+         than not running at all.
+
+         Batches once per file: MSBuild runs a task once per distinct value of item metadata referenced
+         in its parameters, and %(_CurbUnformattedFiles.Identity) is exactly that. -->
+    <Warning Condition="'$(_CurbExitCode)' == '1' and '$(Curb_UnformattedAsWarnings)' == 'true' and '@(_CurbUnformattedFiles)' != ''"
+             Code="CURB0001"
+             File="%(_CurbUnformattedFiles.Identity)"
+             Text="This file is not formatted. Run 'curb format'." />
+
+    <Error Condition="'$(_CurbExitCode)' == '1' and '$(Curb_UnformattedAsWarnings)' != 'true' and '@(_CurbUnformattedFiles)' != ''"
+           Code="CURB0001"
+           File="%(_CurbUnformattedFiles.Identity)"
+           Text="This file is not formatted. Run 'curb format'." />
+
+    <!-- Fallback for a check that reported failure without naming a file, e.g. an older curb.dll
+         (built before the unformatted-list-file flag existed) supplied through $(Curb_Exe). -->
+    <Warning Condition="'$(_CurbExitCode)' == '1' and '$(Curb_UnformattedAsWarnings)' == 'true' and '@(_CurbUnformattedFiles)' == ''"
              Code="CURB0001"
              Text="Some files are not formatted. Run 'curb format', or build without Curb_Check=true." />
 
-    <Error Condition="'$(_CurbExitCode)' == '1' and '$(Curb_UnformattedAsWarnings)' != 'true'"
+    <Error Condition="'$(_CurbExitCode)' == '1' and '$(Curb_UnformattedAsWarnings)' != 'true' and '@(_CurbUnformattedFiles)' == ''"
            Code="CURB0001"
            Text="Some files are not formatted. Run 'curb format', or build without Curb_Check=true." />
 
@@ -185,7 +216,7 @@
     <Touch Condition="'$(_CurbExitCode)' == '0'" Files="$(Curb_StampFile)" AlwaysCreate="true" />
 
     <ItemGroup>
-      <FileWrites Include="$(Curb_StampFile);$(Curb_FileList);$(Curb_CacheFile)" />
+      <FileWrites Include="$(Curb_StampFile);$(Curb_FileList);$(Curb_CacheFile);$(Curb_UnformattedFile)" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
## Summary
- `curb check` now writes back the paths that would change via a new `--unformatted-list-file` flag
- the MSBuild target reads that list and raises one `CURB0001` diagnostic per file (batched on `File="%(...Identity)"`), instead of one message attached to the `.csproj`
- a GitHub Actions annotation for `CURB0001` now names the actual source file, with no filename or line number lookup required
- falls back to the previous project-level message if a check reports failure without naming a file (e.g. an older `curb.dll` supplied through `Curb_Exe`)

Fixes #50

## Test plan
- [x] `dotnet build src/Nullean.Curb.Cli` — builds clean
- [x] `dotnet run --project tests/Nullean.Curb.Tests -- --treenode-filter "/*/Nullean.Curb.Tests.Cli/*/*"` — 43/43 pass
- [x] Ran `examples/curb-msbuild-smoketest` with `Curb_Check=true`: build now fails with `Program.cs : error CURB0001: ...` (file-attributed) instead of the project-attributed message
- [x] Confirmed the normal `format` build path still works and the sample is left in its checked-in misformatted state

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q2uyojR4ARYNGcjezpt2Ry