### PR TITLE
fix: skip non-C# files reaching Curb through an unfiltered explicit file list

### DIFF
--- a/src/Nullean.Curb.Cli/FormattingRun.cs
+++ b/src/Nullean.Curb.Cli/FormattingRun.cs
@@ -80,7 +80,11 @@ internal static class FormattingRun
 
 		string[] files;
 		if (explicitFiles is not null)
-			files = explicitFiles;
+			// The MSBuild integration hands over a project's whole compile set unfiltered — see this
+			// parameter's own doc comment — and a shared Directory.Build.props reaches every project
+			// that imports it, C# or not. @(Compile) for an .fsproj is real .fs paths, not an empty
+			// group, so nothing upstream of here already excludes them.
+			files = [.. explicitFiles.Where(IsFormattable)];
 		else
 		{
 			var root = fileSystem.Path.GetFullPath(target);
@@ -351,8 +355,15 @@ internal static class FormattingRun
 		return new FormattingRunSummary(files.Length, changed, cached, skipped, failed, unparsable, reparsed, coverage, exitCode);
 	}
 
+	/// <summary>
+	/// C# source outside a build-output folder. The directory walk already narrows to this with its
+	/// own <c>"*.cs"</c> glob before the bin/obj half of this ever runs; the extension half exists for
+	/// <paramref name="path"/>s an explicit file list handed over unfiltered, which is what a
+	/// non-C# project reaching Curb through a shared build import looks like from here.
+	/// </summary>
 	private static bool IsFormattable(string path) =>
-		!path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+		path.EndsWith(".cs", StringComparison.OrdinalIgnoreCase)
+		&& !path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
 		&& !path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal);
 }
 

--- a/src/Nullean.Curb.MSBuild/build/curb.targets
+++ b/src/Nullean.Curb.MSBuild/build/curb.targets
@@ -113,7 +113,16 @@
           Condition="'$(Curb_Bypass)' != 'true'
                      and '$(DesignTimeBuild)' != 'true'
                      and '$(BuildingProject)' == 'true'
+                     and '$(Language)' == 'C#'
                      and '@(Compile)' != ''">
+
+    <!--
+      $(Language) rather than the project extension, because a shared Directory.Build.props is what
+      the docs recommend for a solution — putting the package reference in one place — and that
+      reaches every project underneath it whatever it builds. @(Compile) is real source paths in an
+      .fsproj too, not an empty group, so without this an F# project's own files would be handed to a
+      C# parser and reported as files that do not parse.
+    -->
 
     <!--
       Two layers of incrementality, and the order between them is the point.

--- a/tests/Nullean.Curb.Tests/Cli/FormattingRunTests.cs
+++ b/tests/Nullean.Curb.Tests/Cli/FormattingRunTests.cs
@@ -89,6 +89,23 @@ public class FormattingRunTests
 	}
 
 	[Test]
+	public async Task An_explicit_file_list_skips_files_that_are_not_cs()
+	{
+		// The MSBuild integration hands over @(Compile) unfiltered. A shared Directory.Build.props
+		// reaches every project underneath it, so this list can contain an .fsproj's own .fs files.
+		var fs = Repo();
+		fs.AddFile($"{Root}/Mine.cs", new MockFileData("class Mine {    }"));
+		fs.AddFile($"{Root}/Theirs.fs", new MockFileData("module Theirs"));
+
+		var summary = FormattingRun.Execute(fs, Root, write: true, explicitFiles: [$"{Root}/Mine.cs", $"{Root}/Theirs.fs"]);
+
+		summary.Files.Should().Be(1);
+		summary.Unparsable.Should().Be(0, "the .fs file should never reach the parser");
+		fs.File.ReadAllText($"{Root}/Theirs.fs").Should().Be("module Theirs", "it is not C# and must be left alone");
+		await Task.CompletedTask;
+	}
+
+	[Test]
 	public async Task A_byte_order_mark_survives_a_format_that_was_told_to_keep_it()
 	{
 		var fs = Repo("root = true\n\n[*.cs]\nindent_style = space\ncharset = utf-8-bom\n");


### PR DESCRIPTION
## Summary

- Curb was attempting to parse `.fs` files as C#, emitting spurious "does not parse — { expected" errors. This happened when a solution has both `.csproj` and `.fsproj` projects sharing a `Directory.Build.props` that references the Curb package — the setup the docs themselves recommend for solution-wide adoption.
- Root cause: the directory-walk path already filters to `*.cs` before calling `IsFormattable`, but the explicit-file-list path (fed by `--files` / `--msbuild-list-file`, which is how `curb.targets` invokes the CLI) applied no filtering at all. `curb.targets` writes `@(Compile->'%(FullPath)')` verbatim, and `@(Compile)` for an `.fsproj` is real `.fs` paths, not an empty group.
- Fix, two layers:
  - `FormattingRun.IsFormattable` now also requires a `.cs` extension, and is applied to `explicitFiles` (previously only used by the directory-walk path).
  - `curb.targets`' `Curb` target now also requires `'$(Language)' == 'C#'`, so an F# project never invokes the CLI in the first place — cheaper and more direct than filtering after the fact.

Fixes #49

## Test plan

- [x] Added `An_explicit_file_list_skips_files_that_are_not_cs` to `FormattingRunTests.cs`, mirroring the existing `An_explicit_file_list_is_taken_over_the_directory` pattern: an explicit list with one `.cs` and one `.fs` file, asserting the `.fs` file is neither counted nor written to, and `Unparsable` stays `0`.
- [x] `dotnet build src/Nullean.Curb.Cli -c Release` — 0 warnings, 0 errors.
- [x] Full test suite (`dotnet run --project tests/Nullean.Curb.Tests -c Release`): 1133 succeeded, 0 failed, 5 pre-existing skips.
- [x] Validated `curb.targets` is well-formed XML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015byCT9ghPLnCK3QZf5wNPD