### PR TITLE
fix: sort using-directive segments by lower-case fold, not OrdinalIgnoreCase

### DIFF
--- a/src/Nullean.Curb.Core/Printing/CSharp/UsingOrganiser.cs
+++ b/src/Nullean.Curb.Core/Printing/CSharp/UsingOrganiser.cs
@@ -168,7 +168,7 @@ internal static class UsingOrganiser
 				return system;
 		}
 
-		// Case-insensitive, with ordinal only to break a tie. Ordinal alone sorts every upper-case
+		// Case-insensitive, with ordinal only to break a tie. Plain ordinal sorts every upper-case
 		// letter before every lower-case one, which puts `Microsoft.CodeAnalysis.CSharp.CodeStyle`
 		// ahead of `Microsoft.CodeAnalysis.CodeStyle` — 'S' below 'o'. Verified against the tool
 		// rather than against Roslyn's source: `dotnet format` on a project with
@@ -176,7 +176,12 @@ internal static class UsingOrganiser
 		//
 		// It is the largest single source of churn Curb had on the roslyn repository, whose 17,000
 		// files are sorted the other way by Roslyn's own tooling.
-		var name = string.Compare(Name(left), Name(right), StringComparison.OrdinalIgnoreCase);
+		//
+		// The fold has to be lower-case, not `StringComparison.OrdinalIgnoreCase` — that folds to
+		// upper case internally, which leaves '_' (0x5F) above every letter and sorts
+		// `Foo._Partials` after `Foo.Infrastructure`. dotnet format puts it before, matching what
+		// lower-casing first gets: '_' (0x5F) sits below 'i' (0x69).
+		var name = string.CompareOrdinal(Name(left).ToLowerInvariant(), Name(right).ToLowerInvariant());
 		return name != 0 ? name : string.CompareOrdinal(Name(left), Name(right));
 	}
 

--- a/tests/Nullean.Curb.Tests/Formatting/Options/UsingOrderTests.cs
+++ b/tests/Nullean.Curb.Tests/Formatting/Options/UsingOrderTests.cs
@@ -255,6 +255,29 @@ public class UsingOrderTests : FormattingTest
 		""",
 		editorConfig: "dotnet_sort_system_directives_first = true");
 
+	// ---- underscore-prefixed segments --------------------------------------------------------------
+
+	[Test]
+	public Task An_underscore_prefixed_segment_sorts_before_a_capitalised_one() => Formats(
+		"""
+		using Elastic.ApiExplorer.Infrastructure;
+		using Elastic.ApiExplorer._Partials.Layout;
+		using Elastic.ApiExplorer.Landing;
+
+		public class C { }
+		""",
+		// dotnet format sorts case-insensitively by lower-casing first, which puts '_' (0x5F) below
+		// 'i' (0x69). Case-folding to upper case instead — what plain OrdinalIgnoreCase does — leaves
+		// '_' above every letter and reorders this the other way.
+		"""
+		using Elastic.ApiExplorer._Partials.Layout;
+		using Elastic.ApiExplorer.Infrastructure;
+		using Elastic.ApiExplorer.Landing;
+
+		public class C { }
+		""",
+		editorConfig: "dotnet_sort_system_directives_first = true");
+
 	// ---- block namespaces -------------------------------------------------------------------------
 
 	[Test]


### PR DESCRIPTION
## Summary

- `elastic/docs-builder#3905` found that Curb and `dotnet format` disagree on using-directive sort order for a namespace with an underscore-prefixed segment (`Elastic.ApiExplorer._Partials.Layout`), and had to fix the ordering by hand in one test file after running `dotnet curb format .`.
- Root cause: `UsingOrganiser.Compare` case-folded names via `StringComparison.OrdinalIgnoreCase`, which folds to **upper** case internally. That leaves `_` (0x5F) above every letter, so `_Partials` sorts after `Infrastructure`. `dotnet format`'s own sort folds to **lower** case, where `_` (0x5F) sits below `i` (0x69), so it sorts `_Partials` before `Infrastructure` — the opposite order.
- Verified directly: `string.Compare("_Partials", "Infrastructure", StringComparison.OrdinalIgnoreCase)` returns positive (wrong direction); lower-casing both first and comparing ordinally returns negative (matches `dotnet format`).
- Fix: fold with `.ToLowerInvariant()` + `string.CompareOrdinal` instead of `StringComparison.OrdinalIgnoreCase`. The existing case-sensitive ordinal tie-break is unchanged, and the fix preserves the original motivating case (`Microsoft.CodeAnalysis.CSharp.CodeStyle` sorting after `Microsoft.CodeAnalysis.CodeStyle` — verified by hand with the same test harness).

## Test plan

- [x] Added `An_underscore_prefixed_segment_sorts_before_a_capitalised_one` to `UsingOrderTests.cs`, reproducing the exact docs-builder namespace shape.
- [x] Full test suite (`dotnet run --project tests/Nullean.Curb.Tests -c Release`): 1134 succeeded, 0 failed, 5 pre-existing skips.
- [x] `./build.sh conformance --corpus <elastic/docs-builder checkout>`: 1201/1201 files (100.00%) — confirms the fix, applied to the actual repository that surfaced this, needs no further manual correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015byCT9ghPLnCK3QZf5wNPD