### PR TITLE
Hug an expression-bodied lambda whose tail ends with a block

### DIFF
--- a/src/Nullean.Curb.Core/Printing/CSharp/Printers.Expressions.cs
+++ b/src/Nullean.Curb.Core/Printing/CSharp/Printers.Expressions.cs
@@ -605,6 +605,18 @@ internal static partial class Printers
 			return;
 		}
 
+		// An expression body that itself ends with a block — `builder => builder.Add(x => { … })` —
+		// already positions its own contents once that block opens. Wrapping it in a breakable group
+		// as well would let the block's hardline propagate outward and break the group unconditionally,
+		// pushing the whole expression to its own indented line for no reason: the block was always
+		// going to supply the next line.
+		if (expression is not null && EndsWithOwnBlock(expression))
+		{
+			arena.Synthetic(SyntheticText.Space);
+			Node.Print(expression, context);
+			return;
+		}
+
 		using (arena.Group())
 		using (arena.Indent())
 		{

--- a/src/Nullean.Curb.Core/Printing/CSharp/Printers.Expressions.cs
+++ b/src/Nullean.Curb.Core/Printing/CSharp/Printers.Expressions.cs
@@ -605,12 +605,14 @@ internal static partial class Printers
 			return;
 		}
 
-		// An expression body that itself ends with a block — `builder => builder.Add(x => { … })` —
-		// already positions its own contents once that block opens. Wrapping it in a breakable group
-		// as well would let the block's hardline propagate outward and break the group unconditionally,
-		// pushing the whole expression to its own indented line for no reason: the block was always
-		// going to supply the next line.
-		if (expression is not null && EndsWithOwnBlock(expression))
+		// An expression body that itself ends with a block-bodied callback — `builder =>
+		// builder.Add(x => { … })` — already positions its own contents once that block opens.
+		// Wrapping it in a breakable group as well would let the block's hardline propagate outward
+		// and break the group unconditionally, pushing the whole expression to its own indented line
+		// for no reason: the block was always going to supply the next line. EndsWithBlockBodiedCallback
+		// rather than EndsWithOwnBlock: a `with` or object initializer at the tail can still print
+		// flat, and without this group it would lose the only break a long chain ahead of it has.
+		if (expression is not null && EndsWithBlockBodiedCallback(expression))
 		{
 			arena.Synthetic(SyntheticText.Space);
 			Node.Print(expression, context);

--- a/src/Nullean.Curb.Core/Printing/CSharp/Printers.cs
+++ b/src/Nullean.Curb.Core/Printing/CSharp/Printers.cs
@@ -2245,10 +2245,14 @@ internal static partial class Printers
 			ImplicitObjectCreationExpressionSyntax { Initializer: null } implicitCreation =>
 				LastArgumentEndsWithOwnBlock(implicitCreation.ArgumentList),
 
-			// An expression-bodied lambda whose body itself ends with a block — `builder =>
-			// builder.Add(x => { … })` — hugs exactly like a block-bodied one once that block opens.
-			AnonymousFunctionExpressionSyntax { Block: null, ExpressionBody: { } body } =>
-				EndsWithOwnBlock(body),
+			// An expression-bodied lambda whose tail is itself a callback ending in a block — `builder
+			// => builder.Add(x => { … })` — hugs exactly like a block-bodied one once that block opens.
+			// Delegates to the stricter EndsWithBlockBodiedCallback rather than recursing back through
+			// this switch's BringsOwnBlock fallback: a `with` or object initializer at the tail can
+			// still print flat, and unlike an actual block its own group cannot supply the break a long
+			// preceding member chain needs once the outer one is skipped.
+			AnonymousFunctionExpressionSyntax { Block: null } lambda =>
+				EndsWithBlockBodiedCallback(lambda),
 
 			_ => BringsOwnBlock(expression),
 		};
@@ -2256,6 +2260,33 @@ internal static partial class Printers
 	private static bool LastArgumentEndsWithOwnBlock(BaseArgumentListSyntax? arguments) =>
 		arguments is { Arguments.Count: > 0 }
 		&& EndsWithOwnBlock(arguments.Arguments[^1].Expression);
+
+	/// <summary>
+	/// True when an expression, followed strictly through calls and creations, resolves to a
+	/// genuinely block-bodied lambda or anonymous method — the one tail shape guaranteed to hardline
+	/// regardless of how long everything ahead of it is. Deliberately narrower than
+	/// <see cref="EndsWithOwnBlock"/>: a `with` expression or object initializer can still print flat,
+	/// so treating it the same way here would let a caller skip a breakable group that a long chain
+	/// in front of it still needs.
+	/// </summary>
+	internal static bool EndsWithBlockBodiedCallback(ExpressionSyntax expression) =>
+		expression switch
+		{
+			InvocationExpressionSyntax invocation =>
+				LastArgumentEndsWithBlockBodiedCallback(invocation.ArgumentList),
+			ObjectCreationExpressionSyntax { Initializer: null, ArgumentList: { } arguments } =>
+				LastArgumentEndsWithBlockBodiedCallback(arguments),
+			ImplicitObjectCreationExpressionSyntax { Initializer: null } implicitCreation =>
+				LastArgumentEndsWithBlockBodiedCallback(implicitCreation.ArgumentList),
+			AnonymousFunctionExpressionSyntax { Block: null, ExpressionBody: { } body } =>
+				EndsWithBlockBodiedCallback(body),
+			AnonymousFunctionExpressionSyntax function => function.Block is not null,
+			_ => false,
+		};
+
+	private static bool LastArgumentEndsWithBlockBodiedCallback(BaseArgumentListSyntax? arguments) =>
+		arguments is { Arguments.Count: > 0 }
+		&& EndsWithBlockBodiedCallback(arguments.Arguments[^1].Expression);
 
 	/// <summary>Emits the separator between two top-level items, preserving at most one blank line.</summary>
 	private static void Separate(PrintContext context, ref int previousEnd, SyntaxNode next)

--- a/src/Nullean.Curb.Core/Printing/CSharp/Printers.cs
+++ b/src/Nullean.Curb.Core/Printing/CSharp/Printers.cs
@@ -2245,6 +2245,11 @@ internal static partial class Printers
 			ImplicitObjectCreationExpressionSyntax { Initializer: null } implicitCreation =>
 				LastArgumentEndsWithOwnBlock(implicitCreation.ArgumentList),
 
+			// An expression-bodied lambda whose body itself ends with a block — `builder =>
+			// builder.Add(x => { … })` — hugs exactly like a block-bodied one once that block opens.
+			AnonymousFunctionExpressionSyntax { Block: null, ExpressionBody: { } body } =>
+				EndsWithOwnBlock(body),
+
 			_ => BringsOwnBlock(expression),
 		};
 

--- a/tests/Nullean.Curb.Tests/Formatting/Expressions/OperatorTests.cs
+++ b/tests/Nullean.Curb.Tests/Formatting/Expressions/OperatorTests.cs
@@ -269,7 +269,6 @@ public class OperatorTests : FormattingTest
 		""");
 
 	[Test]
-	[Skip("an argument list holding a block-bodied lambda breaks; the lambda should stay on the call line")]
 	public Task Lambda_with_a_block_body() => Unchanged(
 		"""
 		public class C
@@ -280,6 +279,21 @@ public class OperatorTests : FormattingTest
 		        {
 		            return x.Value;
 		        });
+		    }
+		}
+		""");
+
+	[Test]
+	public Task Expression_bodied_lambda_wrapping_a_block_bodied_one() => Unchanged(
+		"""
+		public class C
+		{
+		    public void M()
+		    {
+		        Configure(builder => builder.Add(x =>
+		        {
+		            return x.Value;
+		        }));
 		    }
 		}
 		""");


### PR DESCRIPTION
## Summary
- `builder => builder.Add(x => { … })` broke the outer arrow onto its own indented line: the block-bodied inner lambda's hardline propagated outward through the breakable group `LambdaBody` wraps around an expression body, forcing an unnecessary break even though the block was always going to supply the next line.
- `EndsWithOwnBlock` now looks through an expression-bodied lambda to its tail, and `LambdaBody` hugs the expression directly when it ends with its own block — matching `dotnet format whitespace`.
- Un-skips `Lambda_with_a_block_body` (the originally reported scenario, which turned out to already be correct) and adds `Expression_bodied_lambda_wrapping_a_block_bodied_one` covering the actual nested-lambda bug.

Closes #31.

## Test plan
- [x] Full suite: `dotnet run --project tests/Nullean.Curb.Tests -c Debug --no-build -- --zero-tests-policy strict` — 1140 total, 0 failed, 4 pre-existing skips
- [x] Manually diffed before/after output on 6 repro variants (nested calls, multi-arg lists, member-access chains, `await`, three-deep lambda chains) against a build without the fix — all 5 broken cases now match, negative control unchanged
- [x] Cross-checked against `dotnet format whitespace` (ground truth): output matches
- [x] Verified under both layout modes (no `max_line_length`, and `max_line_length = 100`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015byCT9ghPLnCK3QZf5wNPD