### PR TITLE
Chain-print a receiver that is itself a call or an indexer

### DIFF
--- a/src/Nullean.Curb.Core/Printing/CSharp/Printers.Chains.cs
+++ b/src/Nullean.Curb.Core/Printing/CSharp/Printers.Chains.cs
@@ -231,17 +231,26 @@ internal static partial class Printers
 		var trailerBuffer = context.TrailerBuffer;
 		var trailersStart = trailerBuffer.Count;
 
+		// The outermost invocation/indexer wrapper seen since the last link (or since the start), so a
+		// receiver that is itself a call or an indexer — `GetFactory()`, `factories[0]` — can be handed
+		// back whole rather than disqualifying the chain: without this, `GetFactory().Add(x).Add(y)…`
+		// fell all the way through to ordinary printing and broke inside whichever argument list
+		// happened to overflow first, rather than at the chain's own dots.
+		ExpressionSyntax? receiverBoundary = null;
+
 		while (true)
 		{
 			switch (current)
 			{
 				case InvocationExpressionSyntax invocation:
+					receiverBoundary ??= current;
 					// Append outward: innermost trailers arrive last; reversed below before storing.
 					trailerBuffer.Add(invocation.ArgumentList);
 					current = invocation.Expression;
 					continue;
 
 				case ElementAccessExpressionSyntax elementAccess:
+					receiverBoundary ??= current;
 					trailerBuffer.Add(elementAccess.ArgumentList);
 					current = elementAccess.Expression;
 					continue;
@@ -256,6 +265,7 @@ internal static partial class Printers
 						(links ??= []).Add(new ChainLink(access.OperatorToken, access.Name, trailersStart, trailersCount, end));
 						trailersStart = trailerBuffer.Count;
 						current = access.Expression;
+						receiverBoundary = null;
 						continue;
 					}
 
@@ -265,9 +275,11 @@ internal static partial class Printers
 						var hasReceiverTrailers = trailerBuffer.Count > trailersStart;
 						if (hasReceiverTrailers)
 						{
-							// Remove the receiver's pending trailers — they are not part of any link.
+							// Remove the receiver's pending trailers — they are not part of any link. The
+							// receiver is everything from receiverBoundary down, printed as one unbroken
+							// unit by the ordinary printer for whatever kind of expression it is.
 							trailerBuffer.RemoveRange(trailersStart, trailerBuffer.Count - trailersStart);
-							receiver = node;
+							receiver = receiverBoundary ?? node;
 						}
 						else
 						{
@@ -275,7 +287,7 @@ internal static partial class Printers
 						}
 						// Links were appended outermost-first; reverse into source order before returning.
 						links?.Reverse();
-						return hasReceiverTrailers ? null : links;
+						return links;
 					}
 			}
 		}

--- a/tests/Nullean.Curb.Tests/Formatting/Options/ChainWrappingTests.cs
+++ b/tests/Nullean.Curb.Tests/Formatting/Options/ChainWrappingTests.cs
@@ -116,4 +116,60 @@ public class ChainWrappingTests : FormattingTest
 		}
 		""",
 		editorConfig: "max_line_length = 120\ncsharp_max_chained_method_calls_on_line = 1");
+
+	// ---- a receiver that is itself a call or an indexer still chains --------------------------------
+
+	[Test]
+	public Task A_bare_call_receiver_still_breaks_at_the_dots() => Formats(
+		// GetFactory() has no leading identifier to collect a link from, so the walk that finds a
+		// chain's receiver used to see its own argument list as unresolved and give up on the whole
+		// expression — the chain never engaged at all, and the line broke wherever an argument list
+		// happened to overflow instead of at the dots.
+		"""
+		public class C
+		{
+		    void M()
+		    {
+		        var result = GetFactory().AddDependency("core").AddDependency("shared").Build();
+		    }
+		}
+		""",
+		"""
+		public class C
+		{
+		    void M()
+		    {
+		        var result = GetFactory()
+		            .AddDependency("core")
+		            .AddDependency("shared")
+		            .Build();
+		    }
+		}
+		""",
+		editorConfig: "max_line_length = 60");
+
+	[Test]
+	public Task An_indexer_receiver_still_breaks_at_the_dots() => Formats(
+		"""
+		public class C
+		{
+		    void M()
+		    {
+		        var result = factories[0].AddDependency("core").AddDependency("shared").Build();
+		    }
+		}
+		""",
+		"""
+		public class C
+		{
+		    void M()
+		    {
+		        var result = factories[0]
+		            .AddDependency("core")
+		            .AddDependency("shared")
+		            .Build();
+		    }
+		}
+		""",
+		editorConfig: "max_line_length = 60");
 }


### PR DESCRIPTION
## Summary
- Fixes a real chain-printer bug: a receiver that is itself a bare call (`GetFactory()`) or an indexer (`factories[0]`) never engaged the chain printer at all, so a long chain hanging off one broke wherever an argument list happened to overflow first, rather than at the chain's own dots.
- Found while building concrete examples to demonstrate that Curb's fluent-chain wrapping defaults are internally consistent (`WrapBeforeFirstMethodCall`, `WrapAfterDotInMethodCalls`, `WrapChainedMethodCalls`) — this was the one receiver shape that wasn't.

## Root cause
`CollectLinks` (`Printers.Chains.cs`) walks a chain expression innermost-first, treating a plain member access (`Factory.Create` → `.Create`) as cleanly resolving the receiver. A call or indexer receiver has its own trailing argument/bracket list, which the walk queued as "pending" and, on reaching the identifier underneath with trailers still pending, treated as disqualifying the whole expression — returning `null` and discarding every link already collected.

## Fix
Track the outermost invocation/indexer wrapper seen since the last resolved link (`receiverBoundary`), reset whenever a link is formed. When the walk terminates with pending trailers, hand back that wrapper as the receiver instead of discarding the collected links. Such a receiver never matches `WrapBeforeFirstMethodCall`'s "plain identifier" check, so it correctly stands alone the same way any other "more involved" receiver already did — the fix only restores the printer to its own documented intent, no option semantics changed.

## Before / after
```csharp
// before: falls through to ordinary printing, breaks inside an argument list
var result = GetFactory().AddDependency("core").AddDependency(
    "shared"
).AddDependency("extra").Build();

// after: chain-prints like any other "more involved" receiver
var result = GetFactory()
    .AddDependency("core")
    .AddDependency("shared")
    .AddDependency("extra")
    .Build();
```

## Test plan
- [x] Two new regression cases in `ChainWrappingTests.cs` (bare-call receiver, indexer receiver)
- [x] `dotnet run --project tests/Nullean.Curb.Tests -c Release` — 1185 passed, 0 failed, 4 skipped
- [x] `./build.sh verifyexpectations` — green, same 9 pre-existing documented divergences, no new ones
- [x] `./build.sh options` — no docs diff (no default/descriptor changed)
- [x] Idempotency spot-check: formatted output re-run through `curb format` reports 0 changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S276QzXtNwZdHHDZnUeZTX