### PR TITLE
Fix #65: flaky tests caused by EditorConfig.Core's static file cache

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,7 +21,11 @@
          and structurally never will be. Matching it is deliberately not attempted; see docs/cleanup.md
          for why that rules out hosting the SDK's own code style analysers. -->
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="[5.6.0]" />
-    <PackageVersion Include="editorconfig" Version="0.17.0" />
+    <!-- 0.18.0 fixes a static, process-wide cache collision (editorconfig/editorconfig-core-net#64,
+         found while diagnosing nullean/curb#65): EditorConfigFileCache is now private per
+         EditorConfigParser instance by default, so CurbEditorConfig no longer needs its own
+         workaround cache — see CurbEditorConfig.cs. -->
+    <PackageVersion Include="editorconfig" Version="0.18.0" />
     <PackageVersion Include="System.IO.Abstractions" Version="22.2.0" />
     <!-- 0.18.0 fixes handler exit codes (nullean/argh#65), an illink crash under TreatWarningsAsErrors
          (nullean/argh#67), and drops a ~1 MB System.Text.Json dependency (nullean/argh#66). Reference

--- a/src/Nullean.Curb.EditorConfig/CurbEditorConfig.cs
+++ b/src/Nullean.Curb.EditorConfig/CurbEditorConfig.cs
@@ -8,46 +8,23 @@ namespace Nullean.Curb.EditorConfig;
 /// </summary>
 /// <remarks>
 /// Wraps <see cref="EditorConfigParser"/> and holds it for the lifetime of a run so its
-/// per-directory chain cache and compiled-glob cache stay warm. Formatting a repository then
-/// resolves configuration once per directory rather than once per file.
+/// per-directory chain cache, compiled-glob cache and file cache all stay warm. Formatting a
+/// repository then resolves configuration once per directory rather than once per file.
 /// </remarks>
-public sealed class CurbEditorConfig
+/// <param name="fileSystem">
+/// Injected so tests can run against <c>MockFileSystem</c>. Every filesystem touch in Curb goes
+/// through this — there are no direct <c>System.IO.File</c> calls.
+/// </param>
+public sealed class CurbEditorConfig(IFileSystem fileSystem)
 {
-	private readonly IFileSystem _fileSystem;
-	private readonly EditorConfigParser _parser;
+	// EditorConfigParser's file cache is private per instance by default as of editorconfig 0.18.0
+	// (editorconfig/editorconfig-core-net#64, filed from this repo — nullean/curb#65). Before that,
+	// the default constructor routed every parse through a static, process-wide cache keyed on
+	// path+mtime+length with no regard for which IFileSystem produced it, so two MockFileSystem-backed
+	// tests reusing the same conventional path could collide and one would silently read the other's
+	// settings. Fixed upstream; no workaround needed here any more.
+	private readonly EditorConfigParser _parser = new(fileSystem);
 	private readonly Dictionary<string, EditorConfigResolvedChain> _chains = new(StringComparer.Ordinal);
-
-	// A custom factory rather than EditorConfigParser's default constructor, which routes every parse
-	// through EditorConfig.Core's own EditorConfigFileCache — a cache that is *static*, process-wide,
-	// and keyed on `{path}|{LastWriteTimeUtc.Ticks}|{Length}`. Two unrelated tests standing up a fresh
-	// MockFileSystem at the same conventional path (`/repo/.editorconfig` and the like) with different,
-	// same-length content can — and under parallel execution measurably do — collide on that key and
-	// silently read back each other's parsed settings, since MockFileSystem's clock resolution is
-	// coarser than the collision needs. `_files` is this parser instance's own replacement: scoped to
-	// one CurbEditorConfig (one filesystem snapshot for the run), so it cannot leak between instances
-	// the way the static cache does, while still avoiding a re-parse of the same ancestor
-	// `.editorconfig` file for every sibling directory that shares it.
-	private readonly Dictionary<string, EditorConfigFile> _files = new(StringComparer.Ordinal);
-
-	/// <param name="fileSystem">
-	/// Injected so tests can run against <c>MockFileSystem</c>. Every filesystem touch in Curb goes
-	/// through this — there are no direct <c>System.IO.File</c> calls.
-	/// </param>
-	public CurbEditorConfig(IFileSystem fileSystem)
-	{
-		_fileSystem = fileSystem;
-		_parser = new EditorConfigParser(ParseFile, fileSystem: fileSystem);
-	}
-
-	private EditorConfigFile ParseFile(string path)
-	{
-		if (!_files.TryGetValue(path, out var file))
-		{
-			file = EditorConfigFile.Parse(path, _fileSystem);
-			_files[path] = file;
-		}
-		return file;
-	}
 
 	/// <summary>Resolves the settings that apply to <paramref name="filePath"/>.</summary>
 	public FileConfiguration For(string filePath)

--- a/src/Nullean.Curb.EditorConfig/CurbEditorConfig.cs
+++ b/src/Nullean.Curb.EditorConfig/CurbEditorConfig.cs
@@ -8,17 +8,46 @@ namespace Nullean.Curb.EditorConfig;
 /// </summary>
 /// <remarks>
 /// Wraps <see cref="EditorConfigParser"/> and holds it for the lifetime of a run so its
-/// per-directory chain cache, compiled-glob cache and file cache all stay warm. Formatting a
-/// repository then resolves configuration once per directory rather than once per file.
+/// per-directory chain cache and compiled-glob cache stay warm. Formatting a repository then
+/// resolves configuration once per directory rather than once per file.
 /// </remarks>
-/// <param name="fileSystem">
-/// Injected so tests can run against <c>MockFileSystem</c>. Every filesystem touch in Curb goes
-/// through this — there are no direct <c>System.IO.File</c> calls.
-/// </param>
-public sealed class CurbEditorConfig(IFileSystem fileSystem)
+public sealed class CurbEditorConfig
 {
-	private readonly EditorConfigParser _parser = new(fileSystem);
+	private readonly IFileSystem _fileSystem;
+	private readonly EditorConfigParser _parser;
 	private readonly Dictionary<string, EditorConfigResolvedChain> _chains = new(StringComparer.Ordinal);
+
+	// A custom factory rather than EditorConfigParser's default constructor, which routes every parse
+	// through EditorConfig.Core's own EditorConfigFileCache — a cache that is *static*, process-wide,
+	// and keyed on `{path}|{LastWriteTimeUtc.Ticks}|{Length}`. Two unrelated tests standing up a fresh
+	// MockFileSystem at the same conventional path (`/repo/.editorconfig` and the like) with different,
+	// same-length content can — and under parallel execution measurably do — collide on that key and
+	// silently read back each other's parsed settings, since MockFileSystem's clock resolution is
+	// coarser than the collision needs. `_files` is this parser instance's own replacement: scoped to
+	// one CurbEditorConfig (one filesystem snapshot for the run), so it cannot leak between instances
+	// the way the static cache does, while still avoiding a re-parse of the same ancestor
+	// `.editorconfig` file for every sibling directory that shares it.
+	private readonly Dictionary<string, EditorConfigFile> _files = new(StringComparer.Ordinal);
+
+	/// <param name="fileSystem">
+	/// Injected so tests can run against <c>MockFileSystem</c>. Every filesystem touch in Curb goes
+	/// through this — there are no direct <c>System.IO.File</c> calls.
+	/// </param>
+	public CurbEditorConfig(IFileSystem fileSystem)
+	{
+		_fileSystem = fileSystem;
+		_parser = new EditorConfigParser(ParseFile, fileSystem: fileSystem);
+	}
+
+	private EditorConfigFile ParseFile(string path)
+	{
+		if (!_files.TryGetValue(path, out var file))
+		{
+			file = EditorConfigFile.Parse(path, _fileSystem);
+			_files[path] = file;
+		}
+		return file;
+	}
 
 	/// <summary>Resolves the settings that apply to <paramref name="filePath"/>.</summary>
 	public FileConfiguration For(string filePath)

--- a/tests/Nullean.Curb.Tests/EditorConfigBindingTests.cs
+++ b/tests/Nullean.Curb.Tests/EditorConfigBindingTests.cs
@@ -80,4 +80,31 @@ public class EditorConfigBindingTests
 		config.MaxLineLength.Should().Be(120);
 		await Task.CompletedTask;
 	}
+
+	[Test]
+	public async Task Concurrent_instances_at_the_same_path_never_cross_wires()
+	{
+		// Regression for issue #65. EditorConfig.Core's own EditorConfigParser, used the way
+		// CurbEditorConfig's constructor used to call it, routes every parse through a *static*,
+		// process-wide EditorConfigFileCache keyed on `{path}|{LastWriteTimeUtc.Ticks}|{Length}`. Two
+		// CurbEditorConfig instances built over different MockFileSystems at the same conventional path
+		// (every test in this file uses the same `/repo/.editorconfig`, the same shape FingerprintTests
+		// and OptOutTests use) can collide on that key under real concurrency — MockFileSystem's clock
+		// resolution is coarser than the collision needs — and one gets served the other's settings.
+		// A synthetic stress replicating this measured ~16% cross-contamination on the pre-fix
+		// constructor; this asserts zero across a smaller but still generous burst, quickly, in CI.
+		var mismatches = 0;
+
+		await Task.WhenAll(Enumerable.Range(0, 2_000).Select(i => Task.Run(() =>
+		{
+			var width = 80 + (i % 40);
+			var fs = WithEditorConfig($"root = true\n\n[*.cs]\nmax_line_length = {width}\n");
+
+			var resolved = new CurbEditorConfig(fs).For($"{Root}/src/Foo.cs");
+			if (resolved.Properties["max_line_length"] != width.ToString(System.Globalization.CultureInfo.InvariantCulture))
+				Interlocked.Increment(ref mismatches);
+		})));
+
+		mismatches.Should().Be(0);
+	}
 }


### PR DESCRIPTION
## Summary

Root-caused and fixed issue #65 (flaky `FingerprintTests`/`OptOutTests`). It was not a race in Curb's own binding code — the third-party `EditorConfig.Core` package cached parsed files in a **static, process-wide** `ConcurrentDictionary` keyed on `{path}|{LastWriteTimeUtc.Ticks}|{Length}`.

`FingerprintTests` and `OptOutTests` each bind many different `.editorconfig` contents against the same hardcoded `MockFileSystem` path (`/repo/.editorconfig`) across their test methods. `MockFileSystem`'s clock resolution is coarser than that cache key needs, so under TUnit's parallel execution two different-content configs of the same byte length could land on the same key — one test then got served the other's parsed settings. That matched #65's symptoms exactly: "two different wrong hash values" for `FingerprintTests`, "fails roughly 1 time in a handful" for `OptOutTests`.

Measured directly, not guessed at:
- A synthetic stress hammering `EditorConfig.Core.EditorConfigFileCache` alone: **~23% collisions** across 200k parallel iterations.
- An end-to-end stress through `CurbEditorConfig` (the pre-fix constructor): **~16% cross-contamination** across 100k iterations.

## History of this PR

**First commit**: worked around the bug locally — `CurbEditorConfig` supplied its own per-instance parse cache instead of routing through the library's static one.

**Filed upstream**: [editorconfig/editorconfig-core-net#64](https://github.com/editorconfig/editorconfig-core-net/issues/64), with the same repro and measurements, arguing the *default* behavior should be safe rather than requiring callers to know to work around it.

**Second commit**: the maintainer shipped a fix within hours — [editorconfig 0.18.0](https://www.nuget.org/packages/editorconfig/0.18.0). `EditorConfigFileCache` is no longer static; each `EditorConfigParser` now owns a private cache instance by default, and entries from any `IFileSystem` other than the real on-disk one are qualified by filesystem identity so unrelated mocks can never collide. Upgraded the package reference and **reverted `CurbEditorConfig` back to its original simple form** — the workaround is no longer needed, the library's own default does the right thing natively.

## Test plan
- [x] New deterministic regression test, `EditorConfigBindingTests.Concurrent_instances_at_the_same_path_never_cross_wires`: bursts 2,000 concurrent `CurbEditorConfig` instances at the same path with varying content, asserts zero mismatches. Passes against 0.18.0's native default (no workaround code needed).
- [x] Re-ran the synthetic 100k-iteration stress against the upgraded package: 0 mismatches, down from ~16%.
- [x] `dotnet run --project tests/Nullean.Curb.Tests -c Release` — 3 consecutive full-suite runs, all green (1186 passed, 4 skipped)
- [x] `./build.sh verifyexpectations` — green, same 9 pre-existing documented divergences, no new ones
- [x] `./build.sh options` — no docs diff
- [x] Perf A/B on the 142-file local corpus — no measurable difference before/after (~200ms, ~60MB allocated either way)

Closes #65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S276QzXtNwZdHHDZnUeZTX