### PR TITLE
Fix broken docs anchor link breaking the docs build

### DIFF
--- a/docs/design-principles/conformance-divergences.md
+++ b/docs/design-principles/conformance-divergences.md
@@ -7,7 +7,7 @@ description: Every case where Curb's output is not a fixed point of dotnet forma
 
 This page lists every known case where {{product}}'s output `Z` is **not a fixed point** of a reference
 tool at all — `T(Z) != Z` — because the tool cannot recognise what {{product}} did, so no shape Curb could
-have chosen instead would fix it. See [conformance](conformance.md#when-tz--z-cannot-hold-at-all) for what
+have chosen instead would fix it. See [conformance](conformance.md#when-tz-z-cannot-hold-at-all) for what
 that means and how it differs from the ordinary, unlisted case of a fixed point in a different shape than
 the tool's own (`X != Z` with `T(Z) == Z` still holding — expected, common, and reported only in aggregate
 by `./build.sh verifyexpectations`, not itemised here). Each row below is a deliberate, investigated choice,


### PR DESCRIPTION
## Summary

Fixes the failing docs build: https://github.com/nullean/curb/actions/runs/33048037459/job/98436567929

`docs/design-principles/conformance-divergences.md` linked to `conformance.md#when-tz--z-cannot-hold-at-all` (two hyphens), but docs-builder generates `when-tz-z-cannot-hold-at-all` (one hyphen) for that heading — confirmed by inspecting the generated HTML's `id` attribute locally.

## Test plan
- [x] `./build.sh docs --noserve` — was `1 Errors / 0 Warnings / 0 Hints`, now `0 Errors / 0 Warnings / 0 Hints`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S276QzXtNwZdHHDZnUeZTX