### PR TITLE
Fix #70: don't count '\r' toward line width when measuring wrap fit

### DIFF
--- a/src/Nullean.Curb.Core/Printing/DocPrinter.cs
+++ b/src/Nullean.Curb.Core/Printing/DocPrinter.cs
@@ -676,6 +676,13 @@ internal sealed class DocPrinter
 				continue;
 			}
 
+			// A source slice can carry a literal '\r' straight from a CRLF-checked-out file (e.g.
+			// Windows with core.autocrlf=true) even when end_of_line is unset. It is a line-ending
+			// byte, not a column of content, so it must not count toward the wrap width — otherwise
+			// wrap decisions diverge between CRLF and LF checkouts of the same source.
+			if (text[i] == '\r')
+				continue;
+
 			if (char.IsHighSurrogate(text[i]) && i + 1 < text.Length && char.IsLowSurrogate(text[i + 1]))
 				i++;
 

--- a/tests/Nullean.Curb.Tests/Printing/DocPrinterTests.cs
+++ b/tests/Nullean.Curb.Tests/Printing/DocPrinterTests.cs
@@ -420,6 +420,36 @@ public class DocPrinterTests
 		await Task.CompletedTask;
 	}
 
+	[Test]
+	public async Task A_carriage_return_in_a_source_span_does_not_count_toward_width()
+	{
+		// A CRLF-checked-out file (e.g. Windows with core.autocrlf=true and end_of_line unset) can hand
+		// the printer a source slice that still carries a literal '\r'. It is a line-ending byte, not a
+		// column of content, and must not count toward the wrap budget — see issue #70, where it made
+		// lines measure one column wider on Windows than on macOS/Linux and flip wrap decisions.
+		const string source = "0123\r678";
+		var arena = new DocArena();
+		using (arena.Group())
+		{
+			arena.SourceText(0, 5); // "0123\r" — 4 columns of content plus a trailing '\r'
+			arena.Line();
+			arena.SourceText(5, 3); // "678"
+		}
+
+		DocValidator.Validate(arena, source.Length);
+		var options = new FormatOptions
+		{
+			MaxLineLength = 8, // "0123" (4) + line-as-space (1) + "678" (3) = 8 columns, ignoring '\r'
+			IndentSize = 2,
+			EndOfLine = EndOfLine.Lf,
+			InsertFinalNewLine = false,
+		};
+
+		DocLayout.Render(arena, source, options).Should().Be("0123\r 678",
+			"the '\\r' must not count toward the 8-column budget, so the group still fits flat");
+		await Task.CompletedTask;
+	}
+
 	// ---- aiming at another group's decision --------------------------------------------------------
 
 	/// <summary>


### PR DESCRIPTION
## Summary

- `DocPrinter.TextWidth` counted a literal `\r` as an ordinary 1-column character. A CRLF-checked-out source file (e.g. Windows with `core.autocrlf=true` and `end_of_line` unset) hands the printer source slices that still carry that `\r`, so the same source measured one column wider on Windows than on macOS/Linux — enough to flip a fits/doesn't-fit wrap decision right at the `max_line_length` boundary (CURB0001 firing only on Windows).
- `TextWidth` now skips `\r` the same way it already special-cases `\t`, mirroring the stripping already done elsewhere (`TokenPrinter`'s verbatim-run and doc-comment paths).

Fixes #70.

## Test plan

- [x] Added `A_carriage_return_in_a_source_span_does_not_count_toward_width` in `DocPrinterTests.cs`, constructing a source span with an embedded `\r` and asserting the group still fits flat at the width it should, not the width a naive `\r`-counted measurement would give.
- [x] `./build.sh test` — full suite passes (1187 succeeded, 4 pre-existing skips, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)