### PR TITLE
Publish curb as a distroless container image + GitHub Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,21 @@ jobs:
           BINARY=$(find .artifacts -name "curb${EXT}" -type f | head -1)
           [[ -n "$BINARY" ]] && ls -la "$BINARY" || echo "(no native binary found)"
 
+      # Container image, linux-x64 only for now — the platform every GitHub-hosted Linux runner
+      # already matches. No --push here and no registry login on this leg, so this only proves the
+      # container build itself still works: AOT compiles, the chiseled base image resolves, and the
+      # SDK's container tooling produces an image in the local Docker daemon. The real push to
+      # ghcr.io happens once, in the build job below, which does pass --push.
+      - name: Build container image (no push)
+        if: matrix.rid == 'linux-x64'
+        run: ./build.sh publishcontainers -s true
+        shell: bash
+
+      - name: Report container image size
+        if: matrix.rid == 'linux-x64'
+        shell: bash
+        run: docker images nullean/curb --format '{{.Tag}}\t{{.Size}}'
+
       - name: Upload per-RID package
         if: github.event_name == 'push'
         uses: actions/upload-artifact@v7
@@ -410,6 +425,21 @@ jobs:
             -k ${{ secrets.GITHUB_TOKEN }} \
             --skip-duplicate \
             --no-symbols; do echo "Retrying"; sleep 1; done
+
+      # ghcr.io/nullean/curb, matching elastic/docs-builder's own tagging: "edge" on every push,
+      # plus "latest" and the semver when this push is an exact release tag — see
+      # publishContainers/containerImageTags in Targets.fs for how that split is decided.
+      - name: Log in to ghcr.io
+        if: github.event_name == 'push'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish container image
+        if: github.event_name == 'push'
+        run: ./build.sh publishcontainers -s true --push
 
       - name: Generate release notes (tag push)
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,25 @@
+name: 'curb'
+description: 'Check or format C# source with curb, driven by your .editorconfig'
+branding:
+  icon: 'code'
+  color: 'blue'
+inputs:
+  path:
+    description: 'File or directory to check/format, relative to the repository root'
+    required: false
+    default: '.'
+  command:
+    description: '"check" fails the job if anything would change; "format" rewrites files in place'
+    required: false
+    default: 'check'
+  args:
+    description: 'Extra arguments passed through to curb verbatim, e.g. "--cache /tmp/curb.cache"'
+    required: false
+    default: ''
+runs:
+  using: 'docker'
+  image: 'docker://ghcr.io/nullean/curb:edge'
+  args:
+    - ${{ inputs.command }}
+    - ${{ inputs.path }}
+    - ${{ inputs.args }}

--- a/build/scripts/CommandLine.fs
+++ b/build/scripts/CommandLine.fs
@@ -23,6 +23,7 @@ type Arguments =
     | [<CliPrefix(CliPrefix.None);SubCommand>] Release
 
     | [<CliPrefix(CliPrefix.None);Hidden;SubCommand>] CreateReleaseOnGithub
+    | [<CliPrefix(CliPrefix.None);Hidden;SubCommand>] PublishContainers
     | [<CliPrefix(CliPrefix.None);SubCommand>] Publish
 
     | [<Inherit>] Corpus of string
@@ -46,6 +47,7 @@ type Arguments =
     | [<Inherit>] Maximum of double
     | [<Inherit;AltCommandLine("-s")>] SingleTarget of bool
     | [<Inherit>] Token of string
+    | [<Inherit>] Push
     | [<Inherit;AltCommandLine("-c")>] CleanCheckout of bool
 with
     interface IArgParserTemplate with
@@ -85,6 +87,7 @@ with
             | SingleTarget _ -> "runs the provided sub command without running its dependencies"
             | Token _ -> "token used to authenticate with github"
             | CleanCheckout _ -> "skip the clean checkout check that guards the release/publish targets"
+            | Push -> "publishcontainers only: push the built image to ghcr.io instead of building it into the local Docker daemon"
 
             | PristineCheck
             | GeneratePackages
@@ -92,6 +95,7 @@ with
             | GenerateReleaseNotes
             | GenerateApiChanges
             | CreateReleaseOnGithub
+            | PublishContainers
                 -> "Undocumented, dependent target"
 
     member this.Name =

--- a/build/scripts/Targets.fs
+++ b/build/scripts/Targets.fs
@@ -1741,6 +1741,45 @@ let private createReleaseOnGithub (arguments:ParseResults<Arguments>) =
 
     exec "dotnet" (["release-notes"] @ releaseArgs) |> ignore
 
+/// Tags for the container image, mirroring the versioning currentVersion already derives from git:
+/// "edge" always (so `ghcr.io/nullean/curb:edge` is always the latest main build), plus "latest" and
+/// the plain semver when this is an exact release tag rather than a canary commit — MinVer's canary
+/// suffix always contains a hyphen, a clean tag never does.
+let private containerImageTags =
+    lazy(
+        let version = currentVersion.Value
+        if version.Contains("-") then "edge" else sprintf "edge;latest;%s" version
+    )
+
+/// Publishes the CLI's native-AOT build as a container image via the .NET SDK's own container
+/// support (`dotnet publish -t:PublishContainer`) — the same mechanism elastic/docs-builder uses for
+/// its own image, not a hand-written Dockerfile. linux-x64 only for now; a second RID becomes a
+/// second manifest-list platform later with no change to action.yml.
+///
+/// Base image is the chiseled/distroless runtime-deps image: no shell, minimal surface, and correct
+/// for an AOT binary specifically because there is no managed runtime to host — a plain `runtime`
+/// image would carry a CLR this binary never uses.
+///
+/// --push is an explicit flag, not inferred from a CI/event-name environment variable: the aot-pack
+/// job's linux-x64 leg calls this on every trigger (PR, push, tag) purely to prove the container
+/// build itself still works, with no ghcr.io credentials configured there, and an env-based "is this
+/// a push?" check would have tried (and failed) to push from that job on every non-PR trigger. Only
+/// the build job, which does log in, passes --push.
+let private publishContainers (arguments:ParseResults<Arguments>) =
+    let baseImageTag = "10.0-noble-chiseled"
+    let registryArgs =
+        if arguments.Contains Push then ["-p"; "ContainerRegistry=ghcr.io"] else []
+    let args =
+        ["publish"; "src/Nullean.Curb.Cli"; "-c"; "Release"; "-r"; "linux-x64"]
+        @ ["/t:PublishContainer"
+           "-p"; "DebugType=none"
+           "-p"; sprintf "ContainerBaseImage=mcr.microsoft.com/dotnet/runtime-deps:%s" baseImageTag
+           "-p"; sprintf "ContainerRepository=%s" Paths.Repository
+           "-p"; sprintf "ContainerImageTags=\"%s\"" containerImageTags.Value
+           "-p"; "ContainerUser=1001:1001"]
+        @ registryArgs
+    exec "dotnet" args |> ignore
+
 /// Timings and metrics for one repository in the compare run.
 type private RepoResult = {
     Name: string
@@ -2033,7 +2072,8 @@ let Setup (parsed:ParseResults<Arguments>) (subCommand:Arguments) =
         <| fun _ -> release parsed
 
     step CreateReleaseOnGithub.Name createReleaseOnGithub
+    step PublishContainers.Name publishContainers
     cmd Publish.Name
         (Some [Release.Name])
-        (Some [CreateReleaseOnGithub.Name])
+        (Some [CreateReleaseOnGithub.Name; PublishContainers.Name])
         <| fun _ -> publish parsed

--- a/docs/curb-landing.html
+++ b/docs/curb-landing.html
@@ -738,6 +738,56 @@ formatting you see in a diff.
   </div>
 </section>
 
+<hr class="divider"/>
+
+<!-- ══════════════  GITHUB ACTION  ══════════════ -->
+<section class="section reveal">
+  <div class="inner">
+    <div class="split">
+      <div>
+        <p class="section-label">// ci without the sdk</p>
+        <h2 class="section-title">Or skip the SDK entirely.</h2>
+        <p class="section-sub" style="margin-bottom:2rem">
+          A pre-built, distroless container image on GitHub Container Registry — pulled, not built, so
+          there is nothing to compile in your workflow. <code>check</code> fails the job if anything
+          would reformat; <code>format</code> rewrites in place.
+        </p>
+        <div class="steps">
+          <div class="step">
+            <div class="step-num">01</div>
+            <div>
+              <div class="step-title">No .NET SDK install</div>
+              <p class="step-body">One <code>uses:</code> line. No <code>actions/setup-dotnet</code>, no tool install, no restore.</p>
+            </div>
+          </div>
+          <div class="step">
+            <div class="step-num">02</div>
+            <div>
+              <div class="step-title">~32 MB, shell-less</div>
+              <p class="step-body">Native-AOT on a chiseled base image. Pulled in about a second, not built on every run.</p>
+            </div>
+          </div>
+          <div class="step">
+            <div class="step-num">03</div>
+            <div>
+              <div class="step-title">Same binary, same rules</div>
+              <p class="step-body">Reads the <code>.editorconfig</code> already in your repo — nothing new to configure.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="code-panel">
+        <div class="code-panel-head">.github/workflows/ci.yml</div>
+<pre><span class="c-tag">- uses:</span> <span class="c-val">nullean/curb@main</span>
+  <span class="c-tag">with:</span>
+    <span class="c-key">command</span>: <span class="c-val">check</span>          <span class="c-com"># or "format"</span>
+    <span class="c-key">path</span>: <span class="c-val">.</span></pre>
+      </div>
+    </div>
+  </div>
+</section>
+
 <!-- ══════════════  CTA  ══════════════ -->
 <section class="section cta reveal">
   <div class="inner">

--- a/docs/curb-landing.html
+++ b/docs/curb-landing.html
@@ -746,7 +746,7 @@ formatting you see in a diff.
     <div class="split">
       <div>
         <p class="section-label">// ci without the sdk</p>
-        <h2 class="section-title">Or skip the SDK entirely.</h2>
+        <h2 class="section-title">Use as GitHub Action.</h2>
         <p class="section-sub" style="margin-bottom:2rem">
           A pre-built, distroless container image on GitHub Container Registry — pulled, not built, so
           there is nothing to compile in your workflow. <code>check</code> fails the job if anything
@@ -763,8 +763,8 @@ formatting you see in a diff.
           <div class="step">
             <div class="step-num">02</div>
             <div>
-              <div class="step-title">~32 MB, shell-less</div>
-              <p class="step-body">Native-AOT on a chiseled base image. Pulled in about a second, not built on every run.</p>
+              <div class="step-title">Pull and run in seconds</div>
+              <p class="step-body">Native-AOT on a chiseled, shell-less base image. Pulled, not built on every run.</p>
             </div>
           </div>
           <div class="step">

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -53,6 +53,41 @@ See [The build integration](../workflow/msbuild.md) for all properties, diagnost
 
 Download the binary for your platform from the GitHub releases page and put it on `PATH`. No SDK required to run it — only to install it via `dotnet tool`.
 
+## GitHub Action
+
+```yaml
+- uses: nullean/curb@main
+  with:
+    path: .            # default; a file or directory
+    command: check      # default; or "format" to rewrite in place
+```
+
+Runs curb from a pre-built, distroless container (`ghcr.io/nullean/curb`) — no .NET SDK install needed in
+the workflow. `command: check` fails the job if anything would be reformatted; switch to `format` to rewrite
+files instead. Extra flags pass through verbatim via `args`:
+
+```yaml
+- uses: nullean/curb@main
+  with:
+    command: check
+    args: --cache /tmp/curb.cache
+```
+
+Linux runners only (`ubuntu-latest` and similar) — container actions can't run on Windows or macOS runners.
+
+## Container image
+
+`ghcr.io/nullean/curb` also works as a general-purpose container, outside GitHub Actions — GitLab CI, a
+local machine without the .NET SDK, anywhere `docker run` works:
+
+```sh
+docker run --rm -v "$(pwd)":/workspace ghcr.io/nullean/curb:edge check /workspace
+```
+
+Distroless: native-AOT, chiseled `runtime-deps` base, no shell, ~32 MB, runs as a non-root user. Tags follow
+curb's own releases — `edge` tracks the latest commit on `main`, `latest` and a semver tag (e.g. `0.6.0`)
+follow tagged releases.
+
 ## Verifying the install
 
 ```sh

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -84,7 +84,7 @@ local machine without the .NET SDK, anywhere `docker run` works:
 docker run --rm -v "$(pwd)":/workspace ghcr.io/nullean/curb:edge check /workspace
 ```
 
-Distroless: native-AOT, chiseled `runtime-deps` base, no shell, ~32 MB, runs as a non-root user. Tags follow
+Distroless: native-AOT, chiseled `runtime-deps` base, no shell, ~53 MB, runs as a non-root user. Tags follow
 curb's own releases — `edge` tracks the latest commit on `main`, `latest` and a semver tag (e.g. `0.6.0`)
 follow tagged releases.
 

--- a/src/Nullean.Curb.Cli/Nullean.Curb.Cli.csproj
+++ b/src/Nullean.Curb.Cli/Nullean.Curb.Cli.csproj
@@ -39,6 +39,9 @@
     <!-- See Nullean.Curb.Core.csproj: Roslyn's command-line-compiler path reads Assembly.Location.
          Curb only ever parses, so this is unreachable. Narrow suppression, not a blanket one. -->
     <NoWarn>$(NoWarn);IL3000</NoWarn>
+    <!-- Lets `dotnet publish -r <rid> -t:PublishContainer` containerize this same AOT publish output —
+         see build/scripts/Targets.fs's publishContainers target and ghcr.io/nullean/curb. -->
+    <EnableSdkContainerSupport>true</EnableSdkContainerSupport>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Adds a distroless container image (`ghcr.io/nullean/curb`) and a GitHub Action (`uses: nullean/curb@main`), the same shape `elastic/docs-builder` already uses — curb's own `docs.yml` already consumes exactly this pattern (`uses: elastic/docs-builder@main`, a docker action pointing at a pre-built ghcr.io image, not a Dockerfile built on every run). Confirmed against docs-builder's real source, not assumed. Also matches the technique in [the linked devblog](https://devblogs.microsoft.com/dotnet/developing-optimized-github-actions-with-net-and-native-aot/): a chiseled/distroless AOT base image referenced via `image: docker://...`, not `image: "Dockerfile"` (which would force a rebuild on every consuming workflow run).

## What's in this PR

- **`Nullean.Curb.Cli.csproj`**: `EnableSdkContainerSupport=true` in the existing RID-gated `PropertyGroup` — lets `dotnet publish -r <rid> -t:PublishContainer` containerize the same AOT publish output. No hand-written Dockerfile, same as docs-builder — the .NET SDK's own container support does the work.
- **New `publishcontainers` build target** (`build/scripts/Targets.fs`): linux-x64 only for now (covers standard GitHub-hosted Linux runners; a second RID becomes a second manifest-list platform later with no `action.yml` change). Chiseled `mcr.microsoft.com/dotnet/runtime-deps:10.0-noble-chiseled` base. Tags: `edge` always, plus `latest`+semver on an exact release tag (derived from the same MinVer version the rest of the release plumbing already uses).
- Pushing is an **explicit `--push` flag**, not CI/event-name env-var sniffing — the `aot-pack` job's linux-x64 leg calls this on every trigger (including pushes to main) purely to prove the container build itself still works, with no registry credentials configured there. An env-based "is this a push?" check would have tried and failed to push from that job too.
- **`ci.yml`**: `aot-pack`'s linux-x64 leg builds the image (no push, reports image size) on every trigger; the `build` job logs in to `ghcr.io` and pushes, gated the same way the existing NuGet-publish steps already are.
- **New `action.yml`**: `uses: nullean/curb@main`, default `command: check` (fails the job if anything would reformat), `format` to rewrite in place, `args` for passthrough flags. Floats on `ghcr.io/nullean/curb:edge`, same as docs-builder's own `action.yml` floating on its `:edge`.
- **`docs/getting-started/installation.md`**: GitHub Action usage, and the image documented as a general-purpose `docker run` tool in its own right (GitLab CI, a local machine without the .NET SDK), not just Action-internal plumbing.
- **Landing page** (`docs/curb-landing.html`): new section advertising the Action, right after "Packages" and before the closing CTA.

## Verification

**Real CI proof, not just local**: the `aot-pack` job's `linux-x64` leg (a real `ubuntu-latest` GitHub-hosted runner) built the container for real on this PR — `Building image 'nullean/curb' with tags 'edge'... Pushed image 'nullean/curb:edge' to local registry via 'docker'`, reporting **53.3 MB**. That's the number now in the docs.

Before that CI run landed, the pipeline was also verified locally: native AOT cross-compilation for `linux-x64` isn't possible on a macOS host (no cross-linker), so the container pipeline was verified by running the equivalent `dotnet publish -t:PublishContainer` natively inside a Linux SDK container matching the build host's own arm64 architecture (`linux-arm64`, standing in for `linux-x64` before CI could confirm it directly):

- Confirmed genuinely shell-less: `docker run --entrypoint sh ...` fails with `executable file not found in $PATH`.
- Entrypoint is `/app/curb`, runs as non-root `1001:1001`.
- Exercised the entrypoint directly: `check` against both a violating file (correct output, exit 1) and a clean file (correct output, exit 0), and `format` rewriting in place — all correct.
- `EnableSdkContainerSupport` doesn't disturb the existing non-container AOT publish or `dotnet pack` paths — both re-tested locally for `osx-arm64`.
- Full test suite and `./build.sh docs`/`./build.sh options` stay green, no unrelated drift.

Real end-to-end push to `ghcr.io` and `uses: nullean/curb@<branch>` action wiring still needs the `build` job to run for real (happens once this merges).

## Test plan
- [x] `dotnet build -c Release` — clean, no warnings
- [x] `dotnet run --project tests/Nullean.Curb.Tests -c Release` — 1186 passed, 0 failed, 4 skipped
- [x] `./build.sh docs --noserve` — 0 errors
- [x] `./build.sh options` — no docs drift
- [x] Container build + entrypoint verified locally, then confirmed for real in CI's `aot-pack` leg (53.3 MB, linux-x64)
- [ ] After merge: confirm `build` pushes `ghcr.io/nullean/curb:edge` for real
- [ ] Exercise `uses: nullean/curb@<branch>` end-to-end against a real violation once the image is live

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S276QzXtNwZdHHDZnUeZTX