### PR TITLE
Move a recursive pattern's opening brace to its own line when it doesn't fit

### DIFF
--- a/src/Nullean.Curb.Core/Printing/CSharp/Printers.Patterns.cs
+++ b/src/Nullean.Curb.Core/Printing/CSharp/Printers.Patterns.cs
@@ -13,6 +13,16 @@ internal static partial class Printers
 		context.Arena.Synthetic(SyntheticText.Space);
 		TokenPrinter.Print(node.IsKeyword, context);
 
+		// A bare recursive pattern (`is { ... }`, no type or positional clause ahead of the brace) that
+		// the author kept on the `is` line owns the gap to its own opening brace: that gap answers the
+		// same fits question as whether the property list wraps, so RecursivePattern controls it with a
+		// fits-aware line instead of a fixed space — see BareRecursivePatternOwnsLeadingBrace.
+		if (BareRecursivePatternOwnsLeadingBrace(node.Pattern, context))
+		{
+			Node.Print(node.Pattern, context);
+			return;
+		}
+
 		// A break the author put after `is` is theirs, the same as one between two alternatives of the
 		// pattern that follows. Without this, `x is` / `A or` / `B` kept its `or` breaks and lost the
 		// first one, which reads worse than either preserving all of them or none.
@@ -23,6 +33,22 @@ internal static partial class Printers
 
 		Node.Print(node.Pattern, context);
 	}
+
+	/// <summary>
+	/// True for the exact shape RecursivePattern defers its leading brace-line to: a property-only
+	/// pattern directly under an <c>is</c> expression, with nothing between the `is` keyword and the
+	/// pattern in the source. Author-broken input keeps the caller's forced line instead, matching every
+	/// other pattern shape.
+	/// </summary>
+	private static bool BareRecursivePatternOwnsLeadingBrace(PatternSyntax pattern, PrintContext context) =>
+		pattern is RecursivePatternSyntax
+		{
+			Type: null,
+			PositionalPatternClause: null,
+			PropertyPatternClause.Subpatterns.Count: > 0,
+			Parent: IsPatternExpressionSyntax isExpression,
+		}
+		&& !context.AuthorBroke(isExpression.IsKeyword.Span.End, pattern.SpanStart);
 
 	public static void DeclarationPattern(DeclarationPatternSyntax node, PrintContext context)
 	{
@@ -56,14 +82,23 @@ internal static partial class Printers
 		if (node.PropertyPatternClause is not null)
 		{
 			var property = node.PropertyPatternClause;
-			if (node.Type is not null || node.PositionalPatternClause is not null)
-				arena.Synthetic(SyntheticText.Space);
+			var hasPrecedingContent = node.Type is not null || node.PositionalPatternClause is not null;
 
-			TokenPrinter.Print(property.OpenBraceToken, context);
 			if (property.Subpatterns.Count > 0)
 			{
+				// The brace has to answer the same fits question as the property list behind it — dotnet
+				// format moves it to its own line whenever that list doesn't fit, the same way an
+				// initializer's brace does. A plain space before an unconditionally-printed brace, as
+				// before, could never move: the group guarding the list only ever affected what came
+				// after the brace, not the brace itself. A bare pattern directly under `is` gets the same
+				// treatment for the `is`-to-brace gap — see BareRecursivePatternOwnsLeadingBrace, whose
+				// caller (IsPatternExpression) skips its own separator in exactly this case.
+				var ownsLeadingGap = hasPrecedingContent || BareRecursivePatternOwnsLeadingBrace(node, context);
 				using (arena.Group())
 				{
+					if (ownsLeadingGap)
+						arena.Line();
+					TokenPrinter.Print(property.OpenBraceToken, context);
 					using (arena.Indent())
 					{
 						arena.Line();
@@ -77,13 +112,17 @@ internal static partial class Printers
 						}
 					}
 					arena.Line();
+					TokenPrinter.Print(property.CloseBraceToken, context);
 				}
 			}
 			else
 			{
+				if (hasPrecedingContent)
+					arena.Synthetic(SyntheticText.Space);
+				TokenPrinter.Print(property.OpenBraceToken, context);
 				arena.Synthetic(SyntheticText.Space);
+				TokenPrinter.Print(property.CloseBraceToken, context);
 			}
-			TokenPrinter.Print(property.CloseBraceToken, context);
 		}
 
 		if (node.Designation is null)

--- a/tests/Nullean.Curb.Tests/Formatting/Expressions/PatternTests.cs
+++ b/tests/Nullean.Curb.Tests/Formatting/Expressions/PatternTests.cs
@@ -1,0 +1,90 @@
+namespace Nullean.Curb.Tests.Formatting.Expressions;
+
+/// <summary>Recursive (property) patterns in <c>is</c> expressions.</summary>
+public class PatternTests : FormattingTest
+{
+	[Test]
+	public Task Typed_recursive_pattern_fits_on_one_line() => Unchanged(
+		"""
+		public class C
+		{
+		    public void M(Exception ex)
+		    {
+		        if (ex is HttpRequestException { StatusCode: 404 })
+		        { }
+		    }
+		}
+		""",
+		editorConfig: "max_line_length = 100");
+
+	[Test]
+	public Task Typed_recursive_pattern_moves_its_brace_to_its_own_line_when_it_does_not_fit() => Formats(
+		"""
+		public class C
+		{
+		    public void M(Exception ex)
+		    {
+		        if (ex is HttpRequestException { StatusCode: HttpStatusCode.NotFound }) { }
+		    }
+		}
+		""",
+		"""
+		public class C
+		{
+		    public void M(Exception ex)
+		    {
+		        if (
+		            ex is HttpRequestException
+		            {
+		                StatusCode: HttpStatusCode.NotFound
+		            }
+		        )
+		        { }
+		    }
+		}
+		""",
+		editorConfig: "max_line_length = 40");
+
+	[Test]
+	public Task Bare_recursive_pattern_fits_on_one_line() => Unchanged(
+		"""
+		public class C
+		{
+		    public void M(object value)
+		    {
+		        if (value is { Length: 0 })
+		        { }
+		    }
+		}
+		""",
+		editorConfig: "max_line_length = 100");
+
+	[Test]
+	public Task Bare_recursive_pattern_moves_its_brace_to_its_own_line_when_it_does_not_fit() => Formats(
+		"""
+		public class C
+		{
+		    public void M(object value)
+		    {
+		        if (value is { Length: 0, Count: 1 }) { }
+		    }
+		}
+		""",
+		"""
+		public class C
+		{
+		    public void M(object value)
+		    {
+		        if (
+		            value is
+		            {
+		                Length: 0,
+		                Count: 1
+		            }
+		        )
+		        { }
+		    }
+		}
+		""",
+		editorConfig: "max_line_length = 40");
+}


### PR DESCRIPTION
## Summary

`dotnet format` moves a property/recursive pattern's `{` onto its own line once the property list no longer fits — whether or not a type precedes it. Curb's `RecursivePattern` printed the brace unconditionally right after a fixed space, so the group guarding the property list could only affect what came *after* the brace, never its own placement. The printer always produced `Type {` glued together, however long the list got.

Found while investigating why `Corpus and conformance` was failing on `main` (https://github.com/nullean/curb/actions/runs/33063013680/job/98486184918): the `elastic/docs-builder` corpus at `max_line_length = 120` diverged from `dotnet format` on 2 files, both this exact shape, pushing conformance to 99.84% — below the 99.9% gate. This predates #71 (`Fix #70`); it was already failing on `main` before that merged, so it's an unrelated, separate bug.

## Examples

### Typed pattern (`Type { ... }`)

At `max_line_length = 40`:

```csharp
if (ex is HttpRequestException { StatusCode: HttpStatusCode.NotFound }) { }
```

Before this fix, curb kept the brace glued to the type and only wrapped the property list:

```csharp
if (
    ex is HttpRequestException {
        StatusCode: HttpStatusCode.NotFound
    }
)
{ }
```

`dotnet format` (and curb, after this fix) puts the brace on its own line, matching how object initializers already behave:

```csharp
if (
    ex is HttpRequestException
    {
        StatusCode: HttpStatusCode.NotFound
    }
)
{ }
```

### Bare pattern (no type — `is { ... }`)

At `max_line_length = 40`:

```csharp
if (value is { Length: 0, Count: 1 }) { }
```

Before this fix:

```csharp
if (
    value is {
        Length: 0,
        Count: 1
    }
)
{ }
```

After this fix (matches `dotnet format`):

```csharp
if (
    value is
    {
        Length: 0,
        Count: 1
    }
)
{ }
```

An author-broken `is`⏎`{ ... }` still keeps its own line as before — that case is untouched by this fix.

## Fix

- `RecursivePattern` (`src/Nullean.Curb.Core/Printing/CSharp/Printers.Patterns.cs`) now folds the open brace into the same group as the property list, using a fits-aware line in place of the fixed space.
- The bare-pattern case (no type, no positional clause) needed `IsPatternExpression` to step aside too, since it otherwise owns the `is`-to-pattern gap with a fixed space that the pattern's own group has no way to turn into a line. It defers only when the source didn't already force a break itself.

## Test plan

- [x] Added `PatternTests.cs` covering both the typed and bare recursive-pattern shapes, fits-on-one-line and forced-to-wrap — the exact examples above.
- [x] `./build.sh test` — full suite passes (1191 succeeded, 4 pre-existing skips, 0 failures).
- [x] Reproduced the conformance failure locally against a fresh `elastic/docs-builder` clone: `./build.sh conformance --corpus <clone> --width 120 --minimum 99.9` went from **99.84% → 100.00%** after this fix. Re-verified default and `--reflow` conformance still pass at 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)