### PR TITLE
Forward one bare dotnet format call instead of two by default

### DIFF
--- a/src/Nullean.Curb.Cleanup/ForwardPlan.cs
+++ b/src/Nullean.Curb.Cleanup/ForwardPlan.cs
@@ -3,14 +3,17 @@ using Nullean.Curb.Options;
 namespace Nullean.Curb.Cleanup;
 
 /// <summary>One <c>dotnet format</c> invocation, covering the diagnostics Curb left behind.</summary>
-/// <param name="Subcommand"><c>style</c> for the IDE series, <c>analyzers</c> for third-party rules.</param>
+/// <param name="Subcommand">
+/// <c>null</c> for the default bare invocation covering everything at once. <c>style</c>/<c>analyzers</c>
+/// only when <c>--no-whitespace</c> asked for the two to run separately.
+/// </param>
 /// <param name="RuleIds">Exactly the ids to fix, sorted. Never a rule the log did not report.</param>
 /// <param name="Files">
 /// Exactly the files the log named, sorted, <b>relative to the working directory</b>. Empty means the
 /// whole project, which is what happens when a file cannot be expressed relatively.
 /// </param>
 public readonly record struct ForwardInvocation(
-	string Subcommand,
+	string? Subcommand,
 	IReadOnlyList<string> RuleIds,
 	IReadOnlyList<string> Files)
 {
@@ -19,11 +22,19 @@ public readonly record struct ForwardInvocation(
 	/// </summary>
 	/// <remarks>
 	/// <para>
-	/// <c>--include</c> is here for blast radius, not for speed. Measured on a 61-file project: 1.97 s with
-	/// it and 1.98 s without, because the cost is the workspace load rather than applying fixes. What it
-	/// does buy is that a file the build never complained about is not rewritten — checked, and a second
-	/// file carrying the identical offence was left untouched. Fixing exactly what was reported is the
-	/// whole premise of cleanup, so forwarding keeps it.
+	/// No subcommand by default: <c>style</c> and <c>analyzers</c> both need the same MSBuild workspace
+	/// loaded, which is the entire cost — 1.97 s narrowed to one file and one rule against 1.98 s over
+	/// everything, so the difference between one invocation and two is a whole second workspace load, not
+	/// the work done in it. The bare command runs whitespace too, but Curb's own output is already
+	/// conformant with <c>dotnet format whitespace</c>, so that pass is a genuine no-op here rather than a
+	/// second opinion on layout. <c>--no-whitespace</c> asks for the split back, for anyone unwilling to
+	/// trust that conformance in their own tree.
+	/// </para>
+	/// <para>
+	/// <c>--include</c> is here for blast radius, not for speed. What it buys is that a file the build never
+	/// complained about is not rewritten — checked, and a second file carrying the identical offence was
+	/// left untouched. Fixing exactly what was reported is the whole premise of cleanup, so forwarding
+	/// keeps it.
 	/// </para>
 	/// <para>
 	/// The paths have to be <b>relative</b>. Measured: an absolute path matches nothing and
@@ -37,10 +48,17 @@ public readonly record struct ForwardInvocation(
 	/// output, it loads an MSBuild workspace, and that is the cost.
 	/// </para>
 	/// </remarks>
-	public IReadOnlyList<string> Arguments =>
-		Files.Count > 0
-			? ["format", Subcommand, "--diagnostics", .. RuleIds, "--severity", "info", "--no-restore", "--include", .. Files]
-			: ["format", Subcommand, "--diagnostics", .. RuleIds, "--severity", "info", "--no-restore"];
+	public IReadOnlyList<string> Arguments
+	{
+		get
+		{
+			IReadOnlyList<string> command = Subcommand is { Length: > 0 } sub ? ["format", sub] : ["format"];
+
+			return Files.Count > 0
+				? [.. command, "--diagnostics", .. RuleIds, "--severity", "info", "--no-restore", "--include", .. Files]
+				: [.. command, "--diagnostics", .. RuleIds, "--severity", "info", "--no-restore"];
+		}
+	}
 
 	/// <summary>The invocation as someone would type it, for reporting.</summary>
 	public string CommandLine => "dotnet " + string.Join(' ', Arguments.Select(Quote));
@@ -53,7 +71,11 @@ public readonly record struct ForwardInvocation(
 public readonly record struct WithheldRule(string Id, string Title, string Reason);
 
 /// <summary>What forwarding would run, and what it deliberately left out.</summary>
-/// <param name="Invocations">At most one per <c>dotnet format</c> subcommand.</param>
+/// <param name="Invocations">
+/// At most one by default — everything forwarded goes to a single bare <c>dotnet format</c> call. At most
+/// two, one per subcommand, when <c>--no-whitespace</c> asked to keep <c>style</c> and <c>analyzers</c>
+/// separate.
+/// </param>
 /// <param name="Withheld">Rules Curb will not hand to another tool either, with the reason.</param>
 /// <param name="Quiet">How many diagnostics were skipped for being reported below warning.</param>
 public readonly record struct ForwardResult(
@@ -94,7 +116,12 @@ public static class ForwardPlan
 	/// cannot be named in <c>--include</c>, and rather than let it match nothing the invocation drops
 	/// <c>--include</c> altogether and widens to the project.
 	/// </param>
-	public static ForwardResult For(IEnumerable<CleanupDiagnostic> unfixed, string workingDirectory)
+	/// <param name="separateWhitespace">
+	/// From <c>--no-whitespace</c>: keep <c>style</c> and <c>analyzers</c> as two invocations instead of one
+	/// bare <c>dotnet format</c>, so the whitespace formatter never runs.
+	/// </param>
+	public static ForwardResult For(
+		IEnumerable<CleanupDiagnostic> unfixed, string workingDirectory, bool separateWhitespace = false)
 	{
 		var style = new SortedSet<string>(StringComparer.Ordinal);
 		var analyzers = new SortedSet<string>(StringComparer.Ordinal);
@@ -153,11 +180,24 @@ public static class ForwardPlan
 
 		// One un-includable file widens the whole invocation, because a partial `--include` would silently
 		// skip it while looking like a complete run.
-		if (style.Count > 0)
-			invocations.Add(new ForwardInvocation("style", [.. style], unscoped ? [] : [.. styleFiles]));
+		if (separateWhitespace)
+		{
+			if (style.Count > 0)
+				invocations.Add(new ForwardInvocation("style", [.. style], unscoped ? [] : [.. styleFiles]));
 
-		if (analyzers.Count > 0)
-			invocations.Add(new ForwardInvocation("analyzers", [.. analyzers], unscoped ? [] : [.. analyzerFiles]));
+			if (analyzers.Count > 0)
+				invocations.Add(new ForwardInvocation("analyzers", [.. analyzers], unscoped ? [] : [.. analyzerFiles]));
+		}
+		else if (style.Count > 0 || analyzers.Count > 0)
+		{
+			var ruleIds = new SortedSet<string>(style, StringComparer.Ordinal);
+			ruleIds.UnionWith(analyzers);
+
+			var files = new SortedSet<string>(styleFiles, StringComparer.Ordinal);
+			files.UnionWith(analyzerFiles);
+
+			invocations.Add(new ForwardInvocation(null, [.. ruleIds], unscoped ? [] : [.. files]));
+		}
 
 		return new ForwardResult([.. invocations], [.. withheld.Values], quiet);
 	}

--- a/src/Nullean.Curb.Cli/CleanupRun.cs
+++ b/src/Nullean.Curb.Cli/CleanupRun.cs
@@ -38,13 +38,18 @@ internal static class CleanupRun
 	/// <param name="logs">Explicit log paths, from <c>--sarif-log</c>.</param>
 	/// <param name="explicitFiles">Restrict to these files, from <c>--files</c>/<c>--msbuild-list-file</c>. Empty means every file the logs mention.</param>
 	/// <param name="forward">Hand what Curb did not fix to <c>dotnet format</c>, from <c>--forward</c>.</param>
+	/// <param name="separateWhitespace">
+	/// Run <c>style</c> and <c>analyzers</c> as two invocations instead of one bare <c>dotnet format</c>,
+	/// from <c>--no-whitespace</c>.
+	/// </param>
 	public static int Execute(
 		IFileSystem fileSystem,
 		string target,
 		bool write,
 		string[]? logs = null,
 		string[]? explicitFiles = null,
-		bool forward = false)
+		bool forward = false,
+		bool separateWhitespace = false)
 	{
 		logs = logs is { Length: > 0 } ? logs : Discover(fileSystem, target);
 
@@ -248,7 +253,7 @@ internal static class CleanupRun
 		if (forward)
 		{
 			forwardFailed = Forward(
-				fileSystem.Path.GetFullPath(target), [.. notOurs, .. unfixed], stopwatch.ElapsedMilliseconds, write);
+				fileSystem.Path.GetFullPath(target), [.. notOurs, .. unfixed], stopwatch.ElapsedMilliseconds, write, separateWhitespace);
 		}
 
 		if (failed > 0 || forwardFailed)
@@ -270,13 +275,16 @@ internal static class CleanupRun
 	/// </para>
 	/// <para>
 	/// One invocation for the whole target rather than one per project, since the workspace load is the
-	/// cost and doing it repeatedly would multiply the only expensive part.
+	/// cost and doing it repeatedly would multiply the only expensive part. By default that also means one
+	/// bare <c>dotnet format</c> rather than a separate <c>style</c> and <c>analyzers</c> call, since the
+	/// two would each pay for their own workspace load; <c>--no-whitespace</c> asks for the split instead.
 	/// </para>
 	/// </remarks>
 	/// <returns>True when a forwarded invocation failed.</returns>
-	private static bool Forward(string target, IReadOnlyList<CleanupDiagnostic> remainder, long ourMilliseconds, bool write)
+	private static bool Forward(
+		string target, IReadOnlyList<CleanupDiagnostic> remainder, long ourMilliseconds, bool write, bool separateWhitespace)
 	{
-		var plan = ForwardPlan.For(remainder, target);
+		var plan = ForwardPlan.For(remainder, target, separateWhitespace);
 
 		if (plan.Withheld.Count > 0)
 		{
@@ -309,8 +317,10 @@ internal static class CleanupRun
 				? $"{invocation.Files.Count} file(s)"
 				: "the whole project, since a reported file sits outside the working directory";
 
+			var command = invocation.Subcommand is { Length: > 0 } sub ? $"dotnet format {sub}" : "dotnet format";
+
 			Console.WriteLine($"  forwarding {invocation.RuleIds.Count} rule(s) in {scope} "
-				+ $"to `dotnet format {invocation.Subcommand}`: {string.Join(' ', invocation.RuleIds)}");
+				+ $"to `{command}`: {string.Join(' ', invocation.RuleIds)}");
 
 			var start = Stopwatch.StartNew();
 			var exitCode = Run(target, arguments);
@@ -321,7 +331,7 @@ internal static class CleanupRun
 			// failure. Anything else non-zero means the tool could not run.
 			if (exitCode != 0 && !(!write && exitCode == 2))
 			{
-				Console.Error.WriteLine($"  `dotnet format {invocation.Subcommand}` exited {exitCode}");
+				Console.Error.WriteLine($"  `{command}` exited {exitCode}");
 				failed = true;
 			}
 		}

--- a/src/Nullean.Curb.Cli/CurbCommands.cs
+++ b/src/Nullean.Curb.Cli/CurbCommands.cs
@@ -97,15 +97,22 @@ internal sealed class CurbCommands
 	/// Hand what Curb cannot fix to <c>dotnet format</c>, scoped to the reported rules and files, and
 	/// report both timings.
 	/// </param>
+	/// <param name="noWhitespace">
+	/// With <paramref name="forward"/>, run <c>dotnet format style</c> and <c>dotnet format analyzers</c>
+	/// as two separate invocations instead of one bare <c>dotnet format</c>. The default runs whitespace
+	/// too, which is a no-op against Curb's own output, in exchange for loading the MSBuild workspace once
+	/// instead of twice.
+	/// </param>
 	public int Cleanup(
 		[Argument] string path = ".",
 		List<string>? sarifLogs = null,
 		List<FileInfo>? files = null,
 		[Existing] FileInfo? msbuildListFile = null,
 		bool check = false,
-		bool forward = false
+		bool forward = false,
+		bool noWhitespace = false
 	) =>
-		CleanupRun.Execute(_fileSystem, path, write: !check, logs: sarifLogs?.ToArray(), explicitFiles: ResolveExplicitFiles(files, msbuildListFile), forward: forward);
+		CleanupRun.Execute(_fileSystem, path, write: !check, logs: sarifLogs?.ToArray(), explicitFiles: ResolveExplicitFiles(files, msbuildListFile), forward: forward, separateWhitespace: noWhitespace);
 
 	/// <summary>Show which code style rules Curb fixes, and which it does not.</summary>
 	/// <param name="cleanupIds">Print only the ids <c>curb cleanup</c> fixes, space separated, for scripting.</param>

--- a/tests/Nullean.Curb.Tests/Cleanup/ForwardPlanTests.cs
+++ b/tests/Nullean.Curb.Tests/Cleanup/ForwardPlanTests.cs
@@ -26,12 +26,28 @@ public class ForwardPlanTests
 	private static ForwardResult Plan(params CleanupDiagnostic[] diagnostics) =>
 		ForwardPlan.For(diagnostics, Root);
 
+	private static ForwardResult SeparatePlan(params CleanupDiagnostic[] diagnostics) =>
+		ForwardPlan.For(diagnostics, Root, separateWhitespace: true);
+
 	// ---- which subcommand ------------------------------------------------------------------------
 
 	[Test]
-	public async Task The_ide_series_goes_to_style()
+	public async Task By_default_everything_goes_to_one_bare_invocation()
 	{
-		var plan = Plan(Diagnostic("IDE0017"), Diagnostic("IDE0028"));
+		var plan = Plan(Diagnostic("IDE0017"), Diagnostic("CA1822"));
+
+		plan.Invocations.Should().ContainSingle();
+		plan.Invocations[0].Subcommand.Should().BeNull();
+		plan.Invocations[0].RuleIds.Should().Equal("CA1822", "IDE0017");
+		plan.Invocations[0].Arguments.Should().StartWith(["format", "--diagnostics"]);
+
+		await Task.CompletedTask;
+	}
+
+	[Test]
+	public async Task No_whitespace_sends_the_ide_series_to_style()
+	{
+		var plan = SeparatePlan(Diagnostic("IDE0017"), Diagnostic("IDE0028"));
 
 		plan.Invocations.Should().ContainSingle();
 		plan.Invocations[0].Subcommand.Should().Be("style");
@@ -41,9 +57,9 @@ public class ForwardPlanTests
 	}
 
 	[Test]
-	public async Task A_third_party_analyser_goes_to_analyzers()
+	public async Task No_whitespace_sends_a_third_party_analyser_to_analyzers()
 	{
-		var plan = Plan(Diagnostic("CA1822"), Diagnostic("SA1200"));
+		var plan = SeparatePlan(Diagnostic("CA1822"), Diagnostic("SA1200"));
 
 		plan.Invocations.Should().ContainSingle();
 		plan.Invocations[0].Subcommand.Should().Be("analyzers");
@@ -53,9 +69,9 @@ public class ForwardPlanTests
 	}
 
 	[Test]
-	public async Task Both_kinds_produce_one_invocation_each()
+	public async Task No_whitespace_produces_one_invocation_per_kind()
 	{
-		var plan = Plan(Diagnostic("IDE0017"), Diagnostic("CA1822"));
+		var plan = SeparatePlan(Diagnostic("IDE0017"), Diagnostic("CA1822"));
 
 		plan.Invocations.Should().HaveCount(2);
 		plan.Invocations.Select(i => i.Subcommand).Should().Equal("style", "analyzers");
@@ -208,7 +224,7 @@ public class ForwardPlanTests
 	{
 		var arguments = Plan(Diagnostic("IDE0017")).Invocations[0].Arguments;
 
-		arguments.Should().StartWith(["format", "style", "--diagnostics", "IDE0017"]);
+		arguments.Should().StartWith(["format", "--diagnostics", "IDE0017"]);
 		arguments.Should().ContainInOrder("--severity", "info");
 		arguments.Should().Contain("--no-restore", "the build that produced the log already restored");
 		arguments.Should().NotContain("--no-build", "dotnet format has no such flag; it loads a workspace");
@@ -233,8 +249,18 @@ public class ForwardPlanTests
 	{
 		var plan = Plan(Diagnostic("IDE0017", "/repo/my code/Widget.cs"));
 
-		plan.Invocations[0].CommandLine.Should().StartWith("dotnet format style --diagnostics IDE0017");
+		plan.Invocations[0].CommandLine.Should().StartWith("dotnet format --diagnostics IDE0017");
 		plan.Invocations[0].CommandLine.Should().Contain("\"my code", "a path with a space has to survive being read back");
+
+		await Task.CompletedTask;
+	}
+
+	[Test]
+	public async Task No_whitespace_keeps_the_subcommand_in_the_command_line()
+	{
+		var plan = SeparatePlan(Diagnostic("IDE0017", "/repo/my code/Widget.cs"));
+
+		plan.Invocations[0].CommandLine.Should().StartWith("dotnet format style --diagnostics IDE0017");
 
 		await Task.CompletedTask;
 	}


### PR DESCRIPTION
## Summary
- `curb cleanup --forward` used to run `dotnet format style` and `dotnet format analyzers` as two separate invocations, each paying for its own MSBuild workspace load (~2s, the dominant cost regardless of scope).
- Since Curb's own output is already conformant with `dotnet format whitespace`, folding everything into a single bare `dotnet format --diagnostics <style + analyzer ids> ...` call makes the extra whitespace pass a no-op while loading the workspace only once.
- Added `--no-whitespace` to opt back into the previous two-invocation `style`/`analyzers` split, for anyone unwilling to rely on that conformance in their own tree.

## Test plan
- [x] `dotnet build src/Nullean.Curb.Cli` — builds clean
- [x] `dotnet run` in `tests/Nullean.Curb.Tests` — full suite passes (1193 passed, 4 pre-existing unrelated skips, 0 failed)
- [x] `curb cleanup --help` shows the new `--no-whitespace` flag with its description

🤖 Generated with [Claude Code](https://claude.com/claude-code)