### PR TITLE
Fix chain/RHS attachment under reflow: assignments, lambda bodies, receiver stacking

### DIFF
--- a/src/Nullean.Curb.Core/FormatOptions.cs
+++ b/src/Nullean.Curb.Core/FormatOptions.cs
@@ -886,9 +886,11 @@ public readonly record struct FormatOptions
 	/// </summary>
 	/// <remarks>
 	/// <para>
-	/// Null keeps what Curb does: a plain identifier receiver keeps its first call, because
-	/// <c>builder.AddProject(…)</c> reads as one thing, while anything more involved is left to
-	/// stand alone. <c>true</c> strands every receiver; <c>false</c> attaches every first call.
+	/// Null keeps what Curb does, which is the same thing <c>true</c> does: every receiver stands
+	/// alone once a chain is breaking at all, uniform stacking rather than a first call that stays
+	/// attached only because its receiver happened to be a plain identifier. <c>false</c> is the one
+	/// override — it attaches the first call regardless of receiver shape, including a call or
+	/// creation that would otherwise stand alone too.
 	/// </para>
 	/// <para>
 	/// An author's own break at that dot is theirs either way — this decides what Curb does when it

--- a/src/Nullean.Curb.Core/Printing/CSharp/Printers.Chains.cs
+++ b/src/Nullean.Curb.Core/Printing/CSharp/Printers.Chains.cs
@@ -45,7 +45,9 @@ internal static partial class Printers
 		// Declining a two-link chain outright joined `x.SynonymGraph()\n.Synonyms(y)` back onto one
 		// line, and joining anything risks a line too long to break, which is what stopped a file
 		// settling after two runs.
-		if (CountLinks(node) < MinimumLinksToBreak && !SpansLines(node, context))
+		var linkCount = CountLinks(node, out var receiverIsCallShaped);
+		var effectiveLinks = receiverIsCallShaped ? linkCount + 1 : linkCount;
+		if (effectiveLinks < MinimumLinksToBreak && !SpansLines(node, context))
 			return false;
 
 		// Record the trailer buffer base before collecting. All trailer nodes appended by this
@@ -56,7 +58,7 @@ internal static partial class Printers
 		try
 		{
 			var links = CollectLinks(node, context, out var receiver);
-			if (links is null || (links.Count < MinimumLinksToBreak && !SpansLines(node, context)))
+			if (links is null || (effectiveLinks < MinimumLinksToBreak && !SpansLines(node, context)))
 				return false;
 
 
@@ -68,18 +70,14 @@ internal static partial class Printers
 
 			Node.Print(receiver, context);
 
-			// `builder.AddProject(…)` reads as one thing, so a plain identifier receiver keeps its first
-			// call rather than being left stranded on a line of its own — but not when the author put
-			// their own break there, which is theirs to keep.
-			//
-			// csharp_wrap_before_first_method_call overrides the judgement in either direction: true
-			// strands every receiver, false attaches every first call.
+			// Every receiver stands alone once a chain is breaking at all, unset behaving exactly like
+			// csharp_wrap_before_first_method_call = true — uniform stacking reads more consistently
+			// than a first call that stays attached only because its receiver happened to be a plain
+			// identifier. false is the one override left: it attaches the first call regardless of
+			// receiver shape, including a call or creation that would otherwise stand alone too.
 			var attached = context.Options.WrapBeforeFirstMethodCall switch
 			{
-				true => 0,
 				false => 1,
-				null when !asWritten
-					&& receiver is IdentifierNameSyntax or PredefinedTypeSyntax or ThisExpressionSyntax or BaseExpressionSyntax => 1,
 				_ => 0,
 			};
 
@@ -142,30 +140,52 @@ internal static partial class Printers
 		}
 	}
 
-	/// <summary>Counts a chain's links without allocating, so a non-chain costs one walk.</summary>
-	private static int CountLinks(ExpressionSyntax node)
+	/// <summary>
+	/// Counts a chain's links without allocating, so a non-chain costs one walk. Also reports
+	/// whether the receiver itself is call-shaped.
+	/// </summary>
+	/// <remarks>
+	/// A bare call (<c>GetFactory()</c>), an indexer, or a creation with its own arguments
+	/// (<c>new Foo(a, b)</c>) counts as one extra link toward the minimum: <c>new
+	/// Foo(a, b).Bar().Baz()</c> is exactly as chain-like as <c>foo.Bar().Baz().Qux()</c> — three
+	/// genuinely separate steps — even though only two of them are member-access dots. Without
+	/// this, a chain hanging off a call-shaped receiver could sit at the two-link "not really a
+	/// chain" floor forever under reflow: <see cref="SpansLines"/>, the escape hatch preservation
+	/// mode gets for a chain the author already opened out, reads nothing under
+	/// <c>csharp_keep_existing_linebreaks = false</c>, so a receiver that is itself long enough to
+	/// need several lines had no way to earn its tail a break at all — the tail broke inside
+	/// whichever argument list overflowed first instead of at its own dots.
+	/// </remarks>
+	private static int CountLinks(ExpressionSyntax node, out bool receiverIsCallShaped)
 	{
 		var count = 0;
 		var current = node;
+		var lastWasInvocationOrElementAccess = false;
 
 		while (true)
 		{
 			switch (current)
 			{
 				case InvocationExpressionSyntax invocation:
+					lastWasInvocationOrElementAccess = true;
 					current = invocation.Expression;
 					continue;
 
 				case ElementAccessExpressionSyntax elementAccess:
+					lastWasInvocationOrElementAccess = true;
 					current = elementAccess.Expression;
 					continue;
 
 				case MemberAccessExpressionSyntax access when access.IsKind(SyntaxKind.SimpleMemberAccessExpression):
 					count++;
+					lastWasInvocationOrElementAccess = false;
 					current = access.Expression;
 					continue;
 
 				default:
+					receiverIsCallShaped = lastWasInvocationOrElementAccess
+						|| current is ObjectCreationExpressionSyntax { ArgumentList.Arguments.Count: > 0 }
+						|| current is ImplicitObjectCreationExpressionSyntax { ArgumentList.Arguments.Count: > 0 };
 					return count;
 			}
 		}

--- a/src/Nullean.Curb.Core/Printing/CSharp/Printers.Declarations.cs
+++ b/src/Nullean.Curb.Core/Printing/CSharp/Printers.Declarations.cs
@@ -134,17 +134,27 @@ internal static partial class Printers
 	/// redundant, and consulted in deterministic mode only — see the call site for why.
 	/// </remarks>
 	private static bool BreaksWithoutHelp(ExpressionSyntax? value) =>
-		value is InvocationExpressionSyntax
-			or MemberAccessExpressionSyntax
-			or ElementAccessExpressionSyntax
-			or ConditionalAccessExpressionSyntax
-			or BinaryExpressionSyntax
-			or ObjectCreationExpressionSyntax
-			or ImplicitObjectCreationExpressionSyntax
-			// A ternary breaks at its own ? and :, one indent in from wherever it starts. Breaking
-			// after the = as well nests those a level deeper than the assignment they belong to —
-			// issue #34.
-			or ConditionalExpressionSyntax;
+		value switch
+		{
+			// Looks through to the awaited value: `await dynamoDb.PutItemAsync(…)` has the same break
+			// opportunities `dynamoDb.PutItemAsync(…)` does, the `await` keyword adds none of its own
+			// and hides none of the call's.
+			AwaitExpressionSyntax awaitExpression => BreaksWithoutHelp(awaitExpression.Expression),
+
+			InvocationExpressionSyntax
+				or MemberAccessExpressionSyntax
+				or ElementAccessExpressionSyntax
+				or ConditionalAccessExpressionSyntax
+				or BinaryExpressionSyntax
+				or ObjectCreationExpressionSyntax
+				or ImplicitObjectCreationExpressionSyntax
+				// A ternary breaks at its own ? and :, one indent in from wherever it starts. Breaking
+				// after the = as well nests those a level deeper than the assignment they belong to —
+				// issue #34.
+				or ConditionalExpressionSyntax => true,
+
+			_ => false,
+		};
 
 	/// <summary>True for values whose own layout supplies the indentation of their contents.</summary>
 	internal static bool BringsOwnBlock(ExpressionSyntax? value) =>

--- a/src/Nullean.Curb.Core/Printing/CSharp/Printers.Expressions.cs
+++ b/src/Nullean.Curb.Core/Printing/CSharp/Printers.Expressions.cs
@@ -52,18 +52,17 @@ internal static partial class Printers
 		// Where the operand starts, not whether it spans lines — see EqualsValueClause for why the
 		// difference decides whether formatting twice settles.
 		//
-		// A ternary breaks at its own ? and :, one indent in from wherever it starts, so it needs no
-		// hanging indent here either — the same reasoning EqualsValueClause's BreaksWithoutHelp
-		// applies to a declarator's initializer, for the plain-assignment case (issue #34). Scoped to
-		// the ternary alone rather than reusing that whole list: precedence keeps every other member
-		// of it out of reach of an operator's right operand without parentheses (`a && b.Foo()`'s
-		// right side is real and would need its own measurement), but `a ? b : c` binds looser than
-		// every binary operator, so an unparenthesized ternary can only ever land here as an
-		// assignment's RHS.
+		// BreaksWithoutHelp is EqualsValueClause's own fix for the same shape (issue #34), reused
+		// rather than re-derived: `x = a.B().C()` needs exactly the same "has its own break
+		// opportunity, so the operator needs no hanging indent" reasoning `var x = a.B().C()`
+		// already gets. Without it, an assignment whose flat RHS did not fit broke after the
+		// operator and hung the RHS on its own indented line — which then measured as fitting flat
+		// at that new, shallower indent, so the RHS's own chain or argument list never broke either:
+		// the assignment ate the only break the line needed.
 		if (right is ExpressionSyntax expression
 			&& (BringsOwnBlock(expression)
 				|| (operatorEnd >= 0 && context.AuthorJoined(operatorEnd, expression.SpanStart))
-				|| (!context.Options.KeepExistingLinebreaks && expression is ConditionalExpressionSyntax)))
+				|| (!context.Options.KeepExistingLinebreaks && BreaksWithoutHelp(expression))))
 		{
 			Spacing.BeforeOperator(context);
 			Node.Print(right, context);
@@ -633,6 +632,18 @@ internal static partial class Printers
 		// rather than EndsWithOwnBlock: a `with` or object initializer at the tail can still print
 		// flat, and without this group it would lose the only break a long chain ahead of it has.
 		if (expression is not null && EndsWithBlockBodiedCallback(expression))
+		{
+			arena.Synthetic(SyntheticText.Space);
+			Node.Print(expression, context);
+			return;
+		}
+
+		// Same reasoning as OperandOnRight's own BreaksWithoutHelp check, one step further out: a
+		// lambda arrow is an operator like any other, and a body that is itself a chain or a call
+		// has somewhere to break already — `s => s.Indices(…).Query(…).Size(1)` should break at
+		// those dots, not hang the whole flattened body on a line of its own where it then measures
+		// as fitting and never breaks at all.
+		if (expression is not null && !context.Options.KeepExistingLinebreaks && BreaksWithoutHelp(expression))
 		{
 			arena.Synthetic(SyntheticText.Space);
 			Node.Print(expression, context);

--- a/src/Nullean.Curb.Core/Printing/CSharp/Printers.cs
+++ b/src/Nullean.Curb.Core/Printing/CSharp/Printers.cs
@@ -938,6 +938,32 @@ internal static partial class Printers
 			return;
 		}
 
+		// Several arguments where the LAST is a genuinely block-bodied callback — `On("click", () =>
+		// { … })` — hug it the same way a sole argument would: the leading arguments print flat and
+		// comma-separated, then the callback's own block supplies the break, with no list group or
+		// indent wrapping the whole thing. EndsWithBlockBodiedCallback rather than the broader
+		// EndsWithOwnBlock above: with several arguments already inline, only a genuine block
+		// guarantees a break exists to hug against — a `with` or object initializer tail could still
+		// print flat and would leave the list with no break opportunity of its own.
+		if (node.Arguments.Count > 1 && EndsWithBlockBodiedCallback(node.Arguments[^1].Expression))
+		{
+			Spacing.InsideCallParens(context);
+			for (var i = 0; i < node.Arguments.Count - 1; i++)
+			{
+				Node.Print(node.Arguments[i], context);
+				Spacing.BeforeComma(context);
+				TokenPrinter.Print(node.Arguments.GetSeparator(i), context);
+				Spacing.AfterComma(context);
+			}
+
+			context.OwnBlockGroup = 0;
+			Node.Print(node.Arguments[^1], context);
+			Spacing.InsideCallParens(context);
+			TokenPrinter.Print(node.CloseParenToken, context);
+			context.ArgumentListGroup = context.OwnBlockGroup;
+			return;
+		}
+
 		// Named so that an initializer hanging off the creation this list belongs to can put its brace
 		// on its own line exactly when this list wrapped. Published on the way out rather than on the
 		// way in: these lists nest, and it is the outermost one the creation is asking about.

--- a/tests/Nullean.Curb.Tests/Formatting/Expressions/InvocationTests.cs
+++ b/tests/Nullean.Curb.Tests/Formatting/Expressions/InvocationTests.cs
@@ -357,4 +357,67 @@ public class InvocationTests : FormattingTest
 		}
 		""",
 		editorConfig: "max_line_length = 40");
+
+	// ---- a trailing block-bodied callback hugs the call, even with earlier arguments ---------------
+
+	[Test]
+	public Task A_leading_argument_before_a_trailing_callback_stays_inline() => Unchanged(
+		// The single-argument hug only fired for one argument total — `On("click", () => { … })` has
+		// two, so it fell through to the ordinary "wrap every argument" path and exploded the leading
+		// string argument onto its own line for no reason.
+		"""
+		public class C
+		{
+		    public void M()
+		    {
+		        app.Add("", async Task (Cancel _) =>
+		        {
+		            Call();
+		        });
+		    }
+		}
+		""");
+
+	[Test]
+	public Task Several_leading_arguments_before_a_trailing_callback_all_stay_inline() => Unchanged(
+		"""
+		public class C
+		{
+		    public void M()
+		    {
+		        On("click", target, true, () =>
+		        {
+		            Call();
+		        });
+		    }
+		}
+		""");
+
+	[Test]
+	public Task A_trailing_expression_bodied_lambda_does_not_hug_even_with_a_leading_argument() => Formats(
+		// EndsWithBlockBodiedCallback, not the broader EndsWithOwnBlock: a trailing argument that
+		// could still print flat has to leave the list its own break opportunity — hugging it the
+		// same way a genuine block does would strand the list without one.
+		"""
+		public class C
+		{
+		    public void M()
+		    {
+		        Configure(alphaOption, s => s.Indices(betaIndex).Query(gammaQuery));
+		    }
+		}
+		""",
+		"""
+		public class C
+		{
+		    public void M()
+		    {
+		        Configure(
+		            alphaOption,
+		            s => s.Indices(betaIndex).Query(gammaQuery)
+		        );
+		    }
+		}
+		""",
+		editorConfig: "max_line_length = 55");
 }

--- a/tests/Nullean.Curb.Tests/Formatting/Expressions/InvocationTests.cs
+++ b/tests/Nullean.Curb.Tests/Formatting/Expressions/InvocationTests.cs
@@ -349,7 +349,8 @@ public class InvocationTests : FormattingTest
 		{
 		    public void M()
 		    {
-		        instance.First()
+		        instance
+		            .First()
 		            .Second()
 		            .Third()
 		            .Fourth();

--- a/tests/Nullean.Curb.Tests/Formatting/Expressions/ReflowTests.cs
+++ b/tests/Nullean.Curb.Tests/Formatting/Expressions/ReflowTests.cs
@@ -350,4 +350,90 @@ public class ReflowTests : FormattingTest
 		}
 		""",
 		editorConfig: "max_line_length = 28");
+
+	// ---- an operand with its own layout stays attached to the operator that precedes it -----------
+
+	[Test]
+	public Task An_assignments_chain_rhs_stays_attached_and_breaks_at_its_own_dots() => Formats(
+		// Without BreaksWithoutHelp, the RHS hung on its own indented line — which then measured as
+		// fitting flat at that shallower indent, so the chain never broke at its own dots either: the
+		// assignment ate the only break the line needed.
+		"""
+		public class C
+		{
+		    public void M()
+		    {
+		        result = result.WithArgs(alpha).WaitForCompletion(beta).WithParentRelationship(gamma);
+		    }
+		}
+		""",
+		"""
+		public class C
+		{
+		    public void M()
+		    {
+		        result = result.WithArgs(alpha)
+		            .WaitForCompletion(beta)
+		            .WithParentRelationship(gamma);
+		    }
+		}
+		""",
+		editorConfig: "max_line_length = 60");
+
+	[Test]
+	public Task A_discard_assignments_awaited_call_stays_attached() => Formats(
+		// BreaksWithoutHelp looks through the await to the call it wraps — the keyword adds no break
+		// opportunity of its own and hides none of the call's.
+		"""
+		public class C
+		{
+		    public async Task M()
+		    {
+		        _ = await repository.PutItemAsync(alphaArgument, betaArgument, gammaArgument, deltaArgument);
+		    }
+		}
+		""",
+		"""
+		public class C
+		{
+		    public async Task M()
+		    {
+		        _ = await repository.PutItemAsync(
+		            alphaArgument,
+		            betaArgument,
+		            gammaArgument,
+		            deltaArgument
+		        );
+		    }
+		}
+		""",
+		editorConfig: "max_line_length = 60");
+
+	[Test]
+	public Task A_lambda_body_that_is_a_chain_stays_attached_to_its_arrow() => Formats(
+		// Same reasoning as OperandOnRight, one step further out: a lambda arrow is an operator like
+		// any other, and a body that is itself a chain has somewhere to break already.
+		"""
+		public class C
+		{
+		    public void M()
+		    {
+		        Configure(s => s.Indices(alphaIndex).Query(betaQuery).Size(oneResult));
+		    }
+		}
+		""",
+		"""
+		public class C
+		{
+		    public void M()
+		    {
+		        Configure(
+		            s => s.Indices(alphaIndex)
+		                .Query(betaQuery)
+		                .Size(oneResult)
+		        );
+		    }
+		}
+		""",
+		editorConfig: "max_line_length = 45");
 }

--- a/tests/Nullean.Curb.Tests/Formatting/Expressions/ReflowTests.cs
+++ b/tests/Nullean.Curb.Tests/Formatting/Expressions/ReflowTests.cs
@@ -372,7 +372,8 @@ public class ReflowTests : FormattingTest
 		{
 		    public void M()
 		    {
-		        result = result.WithArgs(alpha)
+		        result = result
+		            .WithArgs(alpha)
 		            .WaitForCompletion(beta)
 		            .WithParentRelationship(gamma);
 		    }
@@ -428,7 +429,8 @@ public class ReflowTests : FormattingTest
 		    public void M()
 		    {
 		        Configure(
-		            s => s.Indices(alphaIndex)
+		            s => s
+		                .Indices(alphaIndex)
 		                .Query(betaQuery)
 		                .Size(oneResult)
 		        );

--- a/tests/Nullean.Curb.Tests/Formatting/Options/ChainDotPlacementTests.cs
+++ b/tests/Nullean.Curb.Tests/Formatting/Options/ChainDotPlacementTests.cs
@@ -133,7 +133,7 @@ public class ChainDotPlacementTests : FormattingTest
 
 	[Test]
 	public Task A_receiver_that_keeps_its_first_call_keeps_that_dot_glued() => Formats(
-		// Where Curb introduces the breaks itself, a plain identifier receiver keeps its first call —
+		// csharp_wrap_before_first_method_call = false is the one way left to attach a first call —
 		// and that link has no break for its dot to sit on either side of, so the dot stays glued.
 		"""
 		public class C
@@ -155,5 +155,5 @@ public class ChainDotPlacementTests : FormattingTest
 		    }
 		}
 		""",
-		editorConfig: DotTrails + "\nmax_line_length = 45");
+		editorConfig: DotTrails + "\ncsharp_wrap_before_first_method_call = false\nmax_line_length = 45");
 }

--- a/tests/Nullean.Curb.Tests/Formatting/Options/ChainWrappingTests.cs
+++ b/tests/Nullean.Curb.Tests/Formatting/Options/ChainWrappingTests.cs
@@ -30,7 +30,8 @@ public class ChainWrappingTests : FormattingTest
 		{
 		    void M()
 		    {
-		        instance.First()
+		        instance
+		            .First()
 		            .Second()
 		            .Third()
 		            .Fourth();
@@ -67,7 +68,8 @@ public class ChainWrappingTests : FormattingTest
 		{
 		    void M()
 		    {
-		        var deduped = allUrls.GroupBy(u => u.Location)
+		        var deduped = allUrls
+		            .GroupBy(u => u.Location)
 		            .Select(g => g.First())
 		            .ToList();
 		    }
@@ -172,4 +174,54 @@ public class ChainWrappingTests : FormattingTest
 		}
 		""",
 		editorConfig: "max_line_length = 60");
+
+	// ---- a call-shaped receiver counts toward the minimum, even with only two dots after it --------
+
+	[Test]
+	public Task A_creation_receiver_with_only_two_links_still_breaks_when_it_does_not_fit() => Formats(
+		// Two links (.Configure, .Build) sit below MinimumLinksToBreak on their own, and SpansLines —
+		// preservation mode's escape hatch for a chain the author already opened out — reads nothing
+		// under csharp_keep_existing_linebreaks = false. Without counting the creation's own
+		// arguments as a third link, this chain could never engage at all: the tail broke inside
+		// .Configure's own argument list instead of at its dots.
+		"""
+		public class C
+		{
+		    void M()
+		    {
+		        result = new Builder(alphaArgument, betaArgument).Configure(gammaArgument).Build(deltaArgument);
+		    }
+		}
+		""",
+		"""
+		public class C
+		{
+		    void M()
+		    {
+		        result = new Builder(
+		            alphaArgument,
+		            betaArgument
+		        )
+		            .Configure(gammaArgument)
+		            .Build(deltaArgument);
+		    }
+		}
+		""",
+		editorConfig: "max_line_length = 40");
+
+	[Test]
+	public Task A_creation_receiver_with_no_arguments_does_not_count_toward_the_minimum() => Unchanged(
+		// new Widget() carries nothing of its own to chain against — an empty argument list is as
+		// simple as a plain identifier receiver, so two links after it stays below the minimum same
+		// as foo.Bar().Baz() does, and the line is left to overflow rather than broken for no reason.
+		"""
+		public class C
+		{
+		    void M()
+		    {
+		        result = new Widget().ConfigureSomethingReasonablyLong().BuildSomethingElseEntirely();
+		    }
+		}
+		""",
+		editorConfig: "max_line_length = 40");
 }

--- a/tests/Nullean.Curb.Tests/Formatting/Options/ClosingParenthesisTests.cs
+++ b/tests/Nullean.Curb.Tests/Formatting/Options/ClosingParenthesisTests.cs
@@ -340,14 +340,17 @@ public class ClosingParenthesisTests : FormattingTest
 	// ---- the chain head -------------------------------------------------------------------------------
 
 	[Test]
-	public Task A_plain_receiver_keeps_its_first_call_by_default() => Unchanged(
-		// `source.Where(…)` reads as one thing, so the receiver is not left stranded.
+	public Task A_plain_receiver_stands_alone_by_default() => Unchanged(
+		// Every receiver stands alone once a chain is breaking at all, unset behaving like
+		// csharp_wrap_before_first_method_call = true — uniform stacking rather than a first call
+		// kept attached only because its receiver happened to be a plain identifier.
 		"""
 		public class C
 		{
 		    public void M()
 		    {
-		        var r = source.Where(x => x.Active)
+		        var r = source
+		            .Where(x => x.Active)
 		            .Select(x => x.Name)
 		            .ToList();
 		    }
@@ -356,24 +359,13 @@ public class ClosingParenthesisTests : FormattingTest
 		editorConfig: Narrow);
 
 	[Test]
-	public Task Wrapping_before_the_first_call_strands_the_receiver() => WithAndWithout(
+	public Task Attaching_the_first_call_is_the_one_override_left() => WithAndWithout(
 		"""
 		public class C
 		{
 		    public void M()
 		    {
 		        var r = source.Where(x => x.Active).Select(x => x.Name).ToList();
-		    }
-		}
-		""",
-		"""
-		public class C
-		{
-		    public void M()
-		    {
-		        var r = source.Where(x => x.Active)
-		            .Select(x => x.Name)
-		            .ToList();
 		    }
 		}
 		""",
@@ -389,7 +381,18 @@ public class ClosingParenthesisTests : FormattingTest
 		    }
 		}
 		""",
-		"csharp_wrap_before_first_method_call = true",
+		"""
+		public class C
+		{
+		    public void M()
+		    {
+		        var r = source.Where(x => x.Active)
+		            .Select(x => x.Name)
+		            .ToList();
+		    }
+		}
+		""",
+		"csharp_wrap_before_first_method_call = false",
 		editorConfig: Narrow);
 
 	[Test]


### PR DESCRIPTION
## Summary

Four real formatting regressions found using curb's default reflow on a real PR: [elastic/docs-builder#3948](https://github.com/elastic/docs-builder/pull/3948). All four are fixed here — the first two in the initial commit, the last two added as explicit follow-ups against the same investigation.

## Which `.editorconfig` keys are involved, and what unset means

- **`max_line_length`** is the master switch. Unset (the default), curb never reflows at all — none of this code runs. Every example below assumes it's set (the corpus that surfaced these bugs sets it to `160`).
- **`csharp_keep_existing_linebreaks`** decides which of two mechanisms handles attachment. **Unset**, and a width is set: this defaults to `false` ("deterministic" layout) — this PR's fixes apply. Set to `true` (or `--preserve`): the *existing*, unchanged `AuthorJoined`/`AuthorBroke` mechanism decides instead, based on the author's own source layout — verified directly, this PR changes nothing in that mode.
- **`csharp_wrap_arguments_style`** / **`csharp_max_invocation_arguments_on_line`** do *not* override the new multi-argument hug (case 1) — confirmed directly with `csharp_wrap_arguments_style = chop_always` still hugging.
- **`csharp_wrap_before_first_method_call`** — **this PR flips its unset default.** It used to attach a plain identifier receiver's first call ("`builder.AddProject(…)` reads as one thing") while stranding every other receiver shape. Unset now behaves exactly like `= true`: every receiver stands alone once a chain is breaking at all. `false` remains the one override, attaching the first call regardless of receiver shape. Confirmed this only changes output for a plain identifier/`this`/`base`/predefined-type receiver — every other shape (a call, a creation, a member access) was already stranded by default and is unaffected.

## Case 1 — a trailing callback with a leading argument

**Before:**
```csharp
app.Add("", async Task (Cancel _) =>
{
    await "dotnet tool restore";
    ...
});
```
curb rewrote this to `app.Add(\n    "",\n    async Task (Cancel _) =>\n    {...}\n);` — the leading `""` argument forced onto its own line for no reason. **After this fix:** unchanged.

Root cause: `ArgumentList`'s "hug a sole argument that brings its own block" special case (`Printers.cs`) only fired for *exactly one* argument.

## Case 2 — assignment/lambda-arrow RHS that is a call or chain

**Before:**
```csharp
buildAll = buildAll
    .WithArgs(["assembler", "build", .. GlobalArguments, .. buildArgs])
    .WaitForCompletion(cloneAll)
    .WithParentRelationship(cloneAll);
```
curb rewrote this to `buildAll =` / one long indented line joining the whole chain flat. **After this fix, and the receiver-stacking fix (case 3):**
```csharp
buildAll = buildAll
    .WithArgs(["assembler", "build", .. GlobalArguments, .. buildArgs])
    .WaitForCompletion(cloneAll)
    .WithParentRelationship(cloneAll);
```
— exactly the original.

Root cause: `OperandOnRight` (assignment/binary RHS) and `LambdaBody`'s expression-body fallback only kept an operand attached to its operator for a narrow set of shapes. Everything else broke after the operator and hung the RHS on its own indented line, which then measured as fitting flat at the new, shallower indent — the operator ate the only break the line needed. `EqualsValueClause` (`var x = ...`) already had the fix for this exact shape (`BreaksWithoutHelp`, issue #34); it just never applied to plain assignments or lambda arrow bodies. Reused it in both places, plus an `AwaitExpressionSyntax` look-through so `_ = await Foo.Bar(x)` benefits too.

## Case 3 — every chain receiver stacks once the chain is breaking, not just complex ones

Same example as case 2. Before this PR's default flip, only `buildAll` (a plain identifier) got special-cased attachment; the fix above alone would have produced `buildAll = buildAll.WithArgs(x)` staying joined before the chain broke. Flipping `csharp_wrap_before_first_method_call`'s default makes the receiver stack uniformly with the rest of the chain instead.

## Case 4 — a chain whose receiver is itself call-shaped

**Before:**
```csharp
using var clientSettings = new ElasticsearchClientSettings(
    _nodePool,
    sourceSerializer: (_, settings) => new DefaultSourceSerializer(settings, MessageFeedbackJsonContext.Default)
).DefaultIndex(_indexName).Authentication(auth);
```
`.DefaultIndex(...)` and `.Authentication(...)` stayed glued to the receiver's closing `)`, breaking inside their own argument lists instead of at the dots when the line didn't fit. **After this fix:**
```csharp
using var clientSettings = new ElasticsearchClientSettings(
    _nodePool,
    sourceSerializer: (_, settings) => new DefaultSourceSerializer(settings, MessageFeedbackJsonContext.Default)
)
    .DefaultIndex(_indexName)
    .Authentication(auth);
```

Root cause: a chain only chain-prints once it has `MinimumLinksToBreak` (3) member-access dots. Below that, the escape hatch a chain the author already opened out gets (`SpansLines`) reads nothing under `csharp_keep_existing_linebreaks = false` — so under reflow, a chain with a substantial receiver (a bare call, an indexer, or a creation with its own arguments) but only one or two dots after it could *never* engage chain-printing at all, however badly it overflowed. `CountLinks` now also reports whether the receiver itself is call-shaped and counts it as one extra link toward the minimum — `new Foo(a, b).Bar().Baz()` is exactly as chain-like as `foo.Bar().Baz().Qux()`. An empty-argument creation (`new Widget()`) does **not** count — as simple as a plain identifier receiver.

## Also found and already fixed independently

While investigating case 2, hit a real regression against the corpus: a `var trusted = existing is { ... } && ...` property pattern lost its brace placement once the assignment's own width budget shifted. That turned out to already be fixed on `main` by #73, merged independently while this was in progress, with its own tests — nothing further needed here beyond rebasing onto it.

## Verification

- Full test suite: 1199 passed, 4 pre-existing skips, 0 failures — 8 new/updated regression tests across both commits.
- `./build.sh verifyexpectations` — same 9 pre-existing documented divergences, none new.
- `./build.sh options` — no docs drift.
- A real 1201-file corpus (`elastic/docs-builder`, the same repo the bug reports came from): **100% conformance with `dotnet format`** under reflow, and **idempotent** across two full formatting passes.
- Perf/allocation check on the same corpus: 26.4x source size, within the ~30-31x baseline range — no measurable regression from `CountLinks`'s added receiver tracking.
- Preservation mode (`csharp_keep_existing_linebreaks = true`) verified directly to take the pre-existing, unchanged `AuthorJoined` path.
- `csharp_wrap_arguments_style = chop_always` verified directly to not override the new multi-argument hug.

## Test plan
- [x] `dotnet run --project tests/Nullean.Curb.Tests -c Release` — 1199 passed, 0 failed, 4 skipped
- [x] `./build.sh verifyexpectations` — green, same 9 documented divergences
- [x] `./build.sh options` — no drift
- [x] Real corpus: 100% conformance, idempotent over two passes, perf unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S276QzXtNwZdHHDZnUeZTX