### PR TITLE
Recognize an assignment-expression lambda body as having its own layout

### DIFF
--- a/src/Nullean.Curb.Core/Printing/CSharp/Printers.Declarations.cs
+++ b/src/Nullean.Curb.Core/Printing/CSharp/Printers.Declarations.cs
@@ -151,7 +151,12 @@ internal static partial class Printers
 				// A ternary breaks at its own ? and :, one indent in from wherever it starts. Breaking
 				// after the = as well nests those a level deeper than the assignment they belong to —
 				// issue #34.
-				or ConditionalExpressionSyntax => true,
+				or ConditionalExpressionSyntax
+				// An assignment prints its own left side, operator and OperandOnRight-driven right
+				// side — `context.EnvironmentVariables[k] = v` inside a lambda body needs the arrow
+				// attached to it the same way, not hung on a line of its own only for the assignment
+				// to then decide its own break from a level it does not belong at.
+				or AssignmentExpressionSyntax => true,
 
 			_ => false,
 		};

--- a/tests/Nullean.Curb.Tests/Formatting/Expressions/ReflowTests.cs
+++ b/tests/Nullean.Curb.Tests/Formatting/Expressions/ReflowTests.cs
@@ -438,4 +438,33 @@ public class ReflowTests : FormattingTest
 		}
 		""",
 		editorConfig: "max_line_length = 45");
+
+	[Test]
+	public Task A_lambda_body_that_is_an_assignment_stays_attached_to_its_arrow() => Formats(
+		// An assignment prints its own left side, operator and OperandOnRight-driven right side —
+		// `context.EnvironmentVariables[k] = v` needs the arrow attached to it the same way a chain
+		// body does, not hung on a line of its own only for the assignment to then decide its own
+		// break from a level it does not belong at.
+		"""
+		public class C
+		{
+		    public void M()
+		    {
+		        Configure(context => context.EnvironmentVariables[alphaKey] = betaValue);
+		    }
+		}
+		""",
+		"""
+		public class C
+		{
+		    public void M()
+		    {
+		        Configure(
+		            context => context.EnvironmentVariables[alphaKey] =
+		                betaValue
+		        );
+		    }
+		}
+		""",
+		editorConfig: "max_line_length = 40");
 }


### PR DESCRIPTION
## Summary

Follow-up to #75, same `BreaksWithoutHelp` gap, one more shape reported after that PR merged:

```csharp
.WithEnvironment(context => context.EnvironmentVariables["DOCUMENTATION_ELASTIC_PASSWORD"] = elasticsearchLocal!.Resource.PasswordParameter)
```

curb rewrote this to:
```csharp
.WithEnvironment(
    context =>
        context.EnvironmentVariables["DOCUMENTATION_ELASTIC_PASSWORD"] = elasticsearchLocal!.Resource.PasswordParameter
)
```
— hanging the whole lambda body on its own indented line. `AssignmentExpressionSyntax` wasn't in `BreaksWithoutHelp`'s recognized set, so `LambdaBody`'s "attach, this operand has its own layout" fast path (added in #75 for chains) never fired for a lambda whose body is an assignment.

**After this fix:** the arrow attaches directly to the assignment (`context => context.EnvironmentVariables[...] = ...`), and the assignment then makes its own width decision the normal way — `AssignmentExpression`/`OperandOnRight` already handles that. In this specific example there's no internal break point left once attached (the RHS is a plain member-access chain below the 3-link chain-print minimum), so the line overflows rather than hang-indenting — that's an accepted tradeoff for this shape, not a regression: the alternative (hang-indenting the arrow) is exactly the bug being fixed.

Curb has no way to distinguish a `Func<T, TResult>`-typed lambda from an `Action<T>`-typed one — that requires resolving `WithEnvironment`'s parameter type, which is out of scope (`AGENTS.md`'s scope boundary: curb never loads a compilation). This fix is purely syntactic: an assignment expression, wherever it appears as an operand, gets the same "has its own layout" treatment a chain or an `await`-wrapped call already got in #75.

## Verification

- Full test suite: 1202 passed, 4 pre-existing skips, 0 failures — 1 new regression test (`ReflowTests.cs`).
- `./build.sh verifyexpectations` — same 9 pre-existing documented divergences, none new.
- `./build.sh options` — no docs drift.
- The same 1201-file `elastic/docs-builder` corpus: 100% conformance with `dotnet format` under reflow, idempotent across two full formatting passes.

## Test plan
- [x] `dotnet run --project tests/Nullean.Curb.Tests -c Release` — 1202 passed, 0 failed, 4 skipped
- [x] `./build.sh verifyexpectations` — green, same 9 documented divergences
- [x] `./build.sh options` — no drift
- [x] Real corpus: 100% conformance, idempotent over two passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S276QzXtNwZdHHDZnUeZTX