### PR TITLE
Fix a binary chain's first operand printing one indent level too deep

### DIFF
--- a/docs/reference/wrapping/csharp_wrap_chained_binary_expressions.md
+++ b/docs/reference/wrapping/csharp_wrap_chained_binary_expressions.md
@@ -58,19 +58,19 @@ public class Widget
     )
     {
         return a
-                > 0
+            > 0
             && b
                 > 0
             && c
                 > 0
             && a
-                    + b
+                + b
                 > c
             && a
-                    + c
+                + c
                 > b
             && b
-                    + c
+                + c
                 > a;
     }
 }

--- a/src/Nullean.Curb.Core/Printing/CSharp/Printers.BinaryChains.cs
+++ b/src/Nullean.Curb.Core/Printing/CSharp/Printers.BinaryChains.cs
@@ -81,11 +81,19 @@ internal static partial class Printers
 			}
 		}
 
-		using (arena.IndentIf(!callerAlreadyIndented))
+		// wrap_if_long packs operands onto a line until the next one would not fit, rather than
+		// the group's all-flat-or-all-broken choice the other two values make — see DocKind.Fill.
+		//
+		// Unlike the Group branch below, operand 0 stays inside the same indent scope as the rest
+		// here rather than printing ahead of it — Fill needs a flat, alternating item/separator
+		// child list to pack correctly, and wrapping only part of that list in its own Indent scope
+		// left Fill unable to see the later items as siblings of the first, so it stopped packing
+		// them onto shared lines at all. A first operand carrying its own object initializer can
+		// still land at the wrong indent under this style — narrower than issue #77's report, and
+		// left for a follow-up that finds a fix compatible with Fill's own structure.
+		if (context.Options.WrapChainedBinaryExpressions == WrapStyle.WrapIfLong)
 		{
-			// wrap_if_long packs operands onto a line until the next one would not fit, rather than
-			// the group's all-flat-or-all-broken choice the other two values make — see DocKind.Fill.
-			if (context.Options.WrapChainedBinaryExpressions == WrapStyle.WrapIfLong)
+			using (arena.IndentIf(!callerAlreadyIndented))
 			{
 				using var fill = arena.Fill();
 
@@ -100,20 +108,24 @@ internal static partial class Printers
 					using (fill.Item())
 						Node.Print(operands[i], context);
 				}
-
-				return true;
 			}
 
-			using (arena.Group())
+			return true;
+		}
+
+		using (arena.Group())
+		{
+			// A count, not a fit measurement: chop_always is the same decision
+			// csharp_wrap_arguments_style's chop_always makes, forcing the break outright instead
+			// of leaving it to whether the chain fits.
+			if (context.Options.WrapChainedBinaryExpressions == WrapStyle.ChopAlways)
+				arena.BreakParent();
+
+			// See the WrapIfLong branch above for why operand 0 prints before the indent opens.
+			Node.Print(operands[0], context);
+
+			using (arena.IndentIf(!callerAlreadyIndented))
 			{
-				// A count, not a fit measurement: chop_always is the same decision
-				// csharp_wrap_arguments_style's chop_always makes, forcing the break outright instead
-				// of leaving it to whether the chain fits.
-				if (context.Options.WrapChainedBinaryExpressions == WrapStyle.ChopAlways)
-					arena.BreakParent();
-
-				Node.Print(operands[0], context);
-
 				for (var i = 1; i < operands.Count; i++)
 				{
 					PrintOperator(i - 1);

--- a/tests/Nullean.Curb.Tests/Formatting/Options/ClosingParenthesisTests.cs
+++ b/tests/Nullean.Curb.Tests/Formatting/Options/ClosingParenthesisTests.cs
@@ -693,6 +693,41 @@ public class ClosingParenthesisTests : FormattingTest
 		""",
 		editorConfig: "max_line_length = 120\ncsharp_wrap_chained_binary_expressions = chop_always");
 
+	/// <summary>
+	/// A first operand that carries its own multi-line layout — an object initializer here — used to
+	/// print one indent level deeper than it belongs, because the chain opened its indent scope before
+	/// printing that operand even though the operand itself never actually moved down a line. Roslyn's
+	/// <c>IDE0055</c> rejects the mismatch outright, with no editorconfig key able to reproduce it, so
+	/// this broke the tool's own conformance goal rather than just reading oddly.
+	/// See <see href="https://github.com/nullean/curb/issues/77">issue #77</see>.
+	/// </summary>
+	[Test]
+	public Task A_first_operand_with_an_object_initializer_keeps_its_own_indent() => Formats(
+		"""
+		public class C
+		{
+		    public void M()
+		    {
+		        var query = (Query)new ConstantScoreQuery { Boost = alpha, Name = beta } || new MultiMatchQuery { Query = gamma };
+		    }
+		}
+		""",
+		"""
+		public class C
+		{
+		    public void M()
+		    {
+		        var query = (Query)new ConstantScoreQuery
+		        {
+		            Boost = alpha,
+		            Name = beta
+		        }
+		            || new MultiMatchQuery { Query = gamma };
+		    }
+		}
+		""",
+		editorConfig: Narrow + "\ncsharp_wrap_chained_binary_expressions = chop_if_long");
+
 	// ---- initializer element counts ---------------------------------------------------------------------
 
 	[Test]


### PR DESCRIPTION
## Summary

Closes #77.

When `csharp_wrap_chained_binary_expressions` is set and a binary chain is assigned
(or otherwise printed) directly rather than sitting inside a call's arguments,
`TryPrintBinaryChain` opened its indent scope *before* printing the chain's first
operand — even though that operand always prints attached to whatever precedes the
chain (an assignment's `=`, a condition's `(`), never moved down to its own line. If
that operand carried its own multi-line layout — an object initializer, say — its
brace inherited the extra indent level anyway, landing one level deeper than the
`new` it belongs to.

```csharp
// before
var query = (Query)new ConstantScoreQuery
    {
        Boost = 3.0f,
        Name = "constant-score-query-alpha"
    }
    || new MultiMatchQuery { Query = q };

// after
var query = (Query)new ConstantScoreQuery
{
    Boost = 3.0f,
    Name = "constant-score-query-alpha"
}
    || new MultiMatchQuery { Query = q };
```

Roslyn's `IDE0055` (`CSharpIndentBlockFormattingRule`) rejects the "before" shape
outright — there's no editorconfig key that reproduces it — so this wasn't just an
aesthetic nit, it broke real adoption: a curb-formatted file could fail a
`dotnet build` gate with `EnforceCodeStyleInBuild=true` even though curb's own
conformance checks said it agreed with `dotnet format`.

## Fix

Print operand 0 before opening the indent scope, in the `Group()` branch that backs
`chop_if_long` (the default), `chop_always`, and plain preservation — the shape the
issue itself reports. Nesting an `Indent` inside a `Group` is already the pattern used
throughout this printer; only operand 0 needed to move outside it.

**Not covered**: the `Fill`-backed `wrap_if_long` branch needs the opposite structure
— `Fill` packs items by walking a flat, alternating item/separator child list starting
at the scope it's invoked in, so pulling operand 0's `fill.Item()` out to before the
indent broke `Fill`'s ability to see it as a sibling of the later items (every operand
landed on its own line regardless of fit — caught immediately by the existing
`Binary_operands_pack_onto_a_line_with_wrap_if_long` test). Reverted that branch back
to its original single shared indent scope, so `wrap_if_long` keeps its correct
packing behaviour but doesn't get this fix yet — a first operand with its own
multi-line layout can still misindent specifically under `wrap_if_long`. Documented as
a deferred follow-up in the code comment.

## Also validated

The issue asked whether `var x = (query)new X { }` (an *empty*, multi-line-braced
initializer) is valid too — confirmed yes, via the same real-build check below.

## Verification

- `dotnet format whitespace --verify-no-changes` is **not sufficient** for this bug
  class — confirmed empirically, it returns clean on both the broken and fixed output.
  The real oracle is a full analyzer-driven build:
  `dotnet build -c Release -p:EnforceCodeStyleInBuild=true` with
  `dotnet_diagnostic.IDE0055.severity = error` — **fails with 4 errors** on the
  pre-fix output, **succeeds with 0 errors** on the fix.
- Full test suite: 1207 total, 0 failed (includes a new regression test,
  `A_first_operand_with_an_object_initializer_keeps_its_own_indent`, reproducing the
  issue's exact shape).
- `./build.sh verifyexpectations`: same 9 pre-existing documented divergences, no new
  ones.
- Real 1201-file `elastic/docs-builder` corpus: 100.00% conformance with
  `dotnet format` under reflow, idempotent across two formatting passes.

## Noted, not implemented

The issue also flags a harness gap: curb's corpus check is a text diff against
`dotnet format`, not a real Roslyn-analyzer pass, so it can't catch cases (like this
one) where curb and `dotnet format` agree on text that Roslyn's own formatter still
rejects via `EnforceCodeStyleInBuild=true`. A CI gate running
`dotnet build -p:EnforceCodeStyleInBuild=true` and failing on any IDE0055 error would
close that gap — worth doing, but separate infrastructure work left out of this
change.

## Test plan

- [x] `dotnet run --project tests/Nullean.Curb.Tests -c Release` — 1207 total, 0 failed
- [x] `./build.sh verifyexpectations` — clean, same known divergences
- [x] Real corpus conformance (1201 files) — 100.00%, idempotent
- [x] Real `dotnet build -p:EnforceCodeStyleInBuild=true` — 0 IDE0055 errors on fixed output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S276QzXtNwZdHHDZnUeZTX