### PR TITLE
Rewrite the hero and the AGENTS.md example on the landing page

### DIFF
--- a/docs/curb-landing.html
+++ b/docs/curb-landing.html
@@ -424,12 +424,12 @@
   <div class="inner">
     <div>
       <span class="badge"><span class="badge-dot"></span> syntax + code-style · C# · .NET 10</span>
-      <h1>Fast. Always on.<br/><em>Fully configurable.</em></h1>
+      <h1>A C# formatter for<br/>every <em>dotnet build</em>.</h1>
+      <p class="hero-tagline">Fast. Always on. Fully configurable.</p>
       <p class="hero-sub">
-        Curb runs inside every <code>dotnet build</code> and finishes in milliseconds. It reads your
-        <strong>.editorconfig</strong> when you have one, and works out of the box when you don't.
-        Mechanical style fixes happen before an AI agent ever reports a diagnostic, so it edits less and
-        finishes faster.
+        Curb reads your <strong>.editorconfig</strong> when you have one, and works out of the box when
+        you don't. Mechanical style fixes happen before an AI agent ever reports a diagnostic, so it
+        edits less and finishes faster.
       </p>
       <div class="pkg-commands">
         <div class="pkg-row">
@@ -665,7 +665,7 @@
 
     <div class="grid-2">
       <div class="pass">
-        <span class="pass-tag amber">pass 1 · before compile</span>
+        <span class="pass-tag amber">pass 1 · always on</span>
         <h3>Layout</h3>
         <p>Decided from the parse tree alone. No restore, no compilation, no project system — runs <em>before</em> <code>CoreCompile</code>, rewrites the file, and the compiler reads formatted source.</p>
         <ul>
@@ -677,14 +677,16 @@
         <a class="pass-link" href="reference/">97 options →</a>
       </div>
       <div class="pass">
-        <span class="pass-tag purple">pass 2 · after compile</span>
+        <span class="pass-tag purple">pass 2 · on demand</span>
         <h3>Code-style fixes</h3>
-        <p>Runs on the diagnostics the compiler already reported. Applies fixes the build already knows how to make — no extra analysis step, no separate command to remember.</p>
+        <p>Manual, not automatic. Run <code>curb cleanup</code> yourself after a build, and set
+        <code>EnforceCodeStyleInBuild = true</code> (usually in <code>Directory.Build.props</code>) so
+        the build actually reports the diagnostics it reads.</p>
         <ul>
-          <li>Redundant parentheses (IDE0047 / IDE0048)</li>
-          <li>Unnecessary casts and type annotations</li>
-          <li>Object and collection initialiser style</li>
-          <li>Anything with a Roslyn code fix and a severity in .editorconfig</li>
+          <li>Unused usings, <code>var</code>, readonly fields</li>
+          <li><code>new()</code>, string interpolation, redundant <code>#nullable</code></li>
+          <li>Accessibility modifiers, readonly structs and members</li>
+          <li>Ten rules total. Everything that needs a compilation to decide.</li>
         </ul>
         <a class="pass-link" href="workflow/cleanup/">curb cleanup →</a>
       </div>
@@ -746,11 +748,6 @@ anything else to <span class="c-key">dotnet format style</span>. Always safe
 to add: it skips dotnet format entirely once
 curb has already fixed everything.</pre>
         </div>
-        <p class="stats-note" style="margin-top:-0.9rem; margin-bottom:1.2rem">
-          A close relative of this block runs in
-          <a href="https://github.com/elastic/docs-builder/blob/main/AGENTS.md">elastic/docs-builder's own AGENTS.md</a>
-          today.
-        </p>
 
         <div class="code-panel">
           <div class="code-panel-head">what's left after layout, fixed in one pass</div>

--- a/docs/curb-landing.html
+++ b/docs/curb-landing.html
@@ -424,11 +424,12 @@
   <div class="inner">
     <div>
       <span class="badge"><span class="badge-dot"></span> syntax + code-style · C# · .NET 10</span>
-      <h1>C# style enforcement<br/>on <em>every build</em>.</h1>
+      <h1>Fast. Always on.<br/><em>Fully configurable.</em></h1>
       <p class="hero-sub">
-        A C# formatter built into <code>dotnet build</code>. It reads the <strong>.editorconfig</strong>
-        you already have, agrees with <code>dotnet format</code> and your IDE, and fixes the mechanical
-        work before the compiler reads a line. Formatting just happens.
+        Curb runs inside every <code>dotnet build</code> and finishes in milliseconds. It reads your
+        <strong>.editorconfig</strong> when you have one, and works out of the box when you don't.
+        Mechanical style fixes happen before an AI agent ever reports a diagnostic, so it edits less and
+        finishes faster.
       </p>
       <div class="pkg-commands">
         <div class="pkg-row">
@@ -731,14 +732,25 @@
           <div class="code-panel-head">AGENTS.md — the whole style section</div>
 <pre><span class="c-tag">## Style</span>
 
-Formatting and syntax-level code style are
-applied automatically by the build — see
-<span class="c-key">.editorconfig</span>.
-
+Formatting and syntax-level code style are applied
+automatically by the build. See <span class="c-key">.editorconfig</span>.
 Do not hand-format code, and do not "fix"
 formatting you see in a diff.
-<span class="c-key">dotnet build</span> will do it.</pre>
+<span class="c-key">dotnet build</span> will do it.
+
+After a build reports style diagnostics, run
+<span class="c-key">curb cleanup --forward</span>. It owns IDE0005, IDE0007,
+IDE0034, IDE0040, IDE0044, IDE0071, IDE0090,
+IDE0240, IDE0250, and IDE0251, and forwards
+anything else to <span class="c-key">dotnet format style</span>. Always safe
+to add: it skips dotnet format entirely once
+curb has already fixed everything.</pre>
         </div>
+        <p class="stats-note" style="margin-top:-0.9rem; margin-bottom:1.2rem">
+          A close relative of this block runs in
+          <a href="https://github.com/elastic/docs-builder/blob/main/AGENTS.md">elastic/docs-builder's own AGENTS.md</a>
+          today.
+        </p>
 
         <div class="code-panel">
           <div class="code-panel-head">what's left after layout, fixed in one pass</div>


### PR DESCRIPTION
## Summary

Follow-up to #80. The hero was rewritten a first time and rejected as too
weak, with em dashes the user explicitly ruled out. Presented 4 em-dash-free
alternative angles for evaluation; the user picked "Triad, blunt."

## Changes

- **Hero rewrite** — new H1 ("Fast. Always on. Fully configurable.") and
  sub-copy. States `.editorconfig` is optional (curb works out of the box
  without one, only customizes with one) instead of implying it's required,
  and plants the AI-agent-token-savings idea in the hero itself instead of
  only in the AI section further down the page. Zero em dashes anywhere in
  the new copy.

- **AGENTS.md example panel, expanded** — evaluated against
  [elastic/docs-builder's real `AGENTS.md`](https://github.com/elastic/docs-builder/blob/main/AGENTS.md)
  (fetched and read in full). Their version is good and real: exact rule IDs,
  the `curb cleanup`/`--forward` split. What it's missing, which curb's own
  page already had and keeps: the "do not hand-format, do not fix formatting
  you see in a diff" caveat — without it a diligent agent reformats by hand
  anyway, which is the exact behaviour the block exists to remove. The panel
  now tells the agent to always run `curb cleanup --forward` rather than
  deciding when to add the flag, since forwarding is a no-op once curb has
  already fixed everything. Credits the real file this is modeled on rather
  than presenting it as hypothetical.

- Also evaluated `elastic/docs-builder`'s `.claude/skills/writing-style.md`
  (ISO 24495-1 / ASD-STE100) per the user's question. It's scoped to
  commit/PR/issue prose by its own admission, and even it says to drop
  ASD-STE100's restricted vocabulary. Applied its sentence mechanics (active
  voice, no noun-cluster pile-ups, one term per concept) as a quality bar
  while writing the new copy above, not as a wholesale retrofit of the page's
  existing voice.

## Unchanged

Speed section, GitHub Action section, the 5-card why grid, the `#cli`
pre-commit section, and everything else from #80.

## Verification

- `./build.sh docs --noserve` — succeeds, 0 errors/warnings, override matches
  source exactly.
- Diff against the pre-change file: only the H1, `.hero-sub`, the AGENTS.md
  `<pre>` contents, and its new caption changed.
- Tag-balance check (`section`/`div`/`a`/`pre`/`span`/`p`) — all balanced.
- Confirmed zero em dashes in any new copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S276QzXtNwZdHHDZnUeZTX

## Follow-ups from review

- Split the hero tagline from the H1. "Fast. Always on. Fully configurable."
  is now a smaller amber tagline under a new, descriptive H1 ("A C# formatter
  for every dotnet build"), reusing an existing unused `.hero-tagline`
  component. Trimmed the hero-sub, which had started repeating "runs inside
  every dotnet build."
- Fixed real inaccuracies in the Passes section (flagged as the page's
  weakest): pass 2 (`curb cleanup`) is manual, not automatic, and works best
  with `EnforceCodeStyleInBuild` set (usually in `Directory.Build.props`) so
  the build actually reports the diagnostics it reads. Pass tags now read
  "always on" / "on demand." Also replaced the pass 2 rule list, which named
  `IDE0047`/`IDE0048` (not implemented yet per `CLAUDE.md`) and generic
  categories that don't match, with the real 10 rules `curb cleanup` owns.
- Removed the "runs in elastic/docs-builder's own AGENTS.md" callout under
  the AGENTS.md example panel, per feedback.
