### PR TITLE
Add Open Graph and Twitter Card tags to the landing page

### DIFF
--- a/docs/curb-landing.html
+++ b/docs/curb-landing.html
@@ -3,9 +3,23 @@
 <head>
 <meta charset="UTF-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-<title>Curb — C# style enforcement on every build</title>
-<meta name="description" content="A C# formatter built into dotnet build. Reads the .editorconfig you already have, agrees with dotnet format and your IDE, and fixes the mechanical work before the compiler reads a line."/>
+<title>Curb — A C# formatter for every dotnet build</title>
+<meta name="description" content="Runs inside every dotnet build and finishes in milliseconds. Reads your .editorconfig, agrees with your IDE, and fixes mechanical style before an AI agent ever sees it."/>
 <base href="/"/>
+
+<!-- Social previews: this page is copied verbatim over the generated index.html (see CLAUDE.md),
+     so it never goes through docs-builder's own Open Graph generation and needs these by hand. -->
+<meta property="og:type" content="website"/>
+<meta property="og:url" content="https://curb.nullean.net/"/>
+<meta property="og:title" content="Curb — A C# formatter for every dotnet build"/>
+<meta property="og:description" content="Runs inside every dotnet build and finishes in milliseconds. Reads your .editorconfig, agrees with your IDE, and fixes mechanical style before an AI agent ever sees it."/>
+<meta property="og:image" content="https://curb.nullean.net/_static/curb-lockup-704x384.png"/>
+<meta property="og:image:width" content="704"/>
+<meta property="og:image:height" content="384"/>
+<meta name="twitter:card" content="summary_large_image"/>
+<meta name="twitter:title" content="Curb — A C# formatter for every dotnet build"/>
+<meta name="twitter:description" content="Runs inside every dotnet build and finishes in milliseconds. Reads your .editorconfig, agrees with your IDE, and fixes mechanical style before an AI agent ever sees it."/>
+<meta name="twitter:image" content="https://curb.nullean.net/_static/curb-lockup-704x384.png"/>
 
 <link rel="icon" type="image/svg+xml" href="images/curb-mark.svg"/>
 <link rel="icon" type="image/png" sizes="32x32" href="images/png/curb-mark-32.png"/>


### PR DESCRIPTION
## Summary

`docs/curb-landing.html` is copied verbatim over the generated `index.html`
(see `CLAUDE.md`) rather than passing through docs-builder, so it never got
the `og:*` tags every other generated page picks up automatically from
`_docset.yml`'s `branding.og-image` config. Confirmed by checking a real
generated page (`/getting-started/`) against the landing page directly:
the former has `og:title`/`og:description`/`og:image`/`og:url`, the latter
had none. Sharing `curb.nullean.net` anywhere that reads link previews
(Reddit included) would have produced a bare link.

## Changes

- Adds `og:type`, `og:url`, `og:title`, `og:description`, `og:image`
  (reusing the existing `curb-lockup-704x384.png`, already used site-wide
  for this exact purpose), `og:image:width`/`og:image:height`, and matching
  `twitter:card=summary_large_image` + `twitter:title`/`twitter:description`/
  `twitter:image` tags.
- Refreshes the `<title>` and meta description, which still said the old H1
  text from before the hero rewrite in #81.

## Verification

- `./build.sh docs --noserve` succeeds, override matches source exactly.
- Confirmed the referenced image exists at the real build output path
  (`_static/curb-lockup-704x384.png`), the same path the rest of the site
  already serves it from.
- Tag-balance check unaffected (`meta`/`link` are void elements, 0 closing
  tags expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S276QzXtNwZdHHDZnUeZTX