### PR TITLE
Create a floating major-version tag on each GitHub release

### DIFF
--- a/.github/workflows/create-major-tag.yml
+++ b/.github/workflows/create-major-tag.yml
@@ -1,0 +1,43 @@
+name: create-major-tag
+
+# Lets a workflow pin this repo as a GitHub Action with `uses: nullean/curb@v1` instead of an exact
+# release tag, the same way actions/checkout@v5 stays on v5 across patch and minor releases.
+
+on:
+  release:
+    types:
+      - published
+
+permissions: {}
+
+concurrency:
+  group: create-major-tag
+  cancel-in-progress: false
+
+jobs:
+  create-major-tag:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: true
+
+      - name: Validate and extract major version
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if [[ ! "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Tag '${TAG}' does not match expected semver format (N.N.N)"
+            exit 1
+          fi
+          echo "MAJOR_VERSION=${TAG%%.*}" >> "${GITHUB_ENV}"
+
+      - name: Create major tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git tag "v${MAJOR_VERSION}"
+          git push -f origin "refs/tags/v${MAJOR_VERSION}"


### PR DESCRIPTION
Adds a `create-major-tag.yml` workflow, matching the one being added to `assembly-differ`, `nupkg-validator`, `release-notes`, and `assembly-rewriter`.

**Prompt summary:** Add the same floating major-tag workflow being added to the four other tool repos, to `curb` too, since `curb` already has ghcr.io container publishing and a docker-based `action.yml` but no way to pin a major version of the action itself.

## Why

`action.yml` already lets a workflow do `uses: nullean/curb@<exact-tag>`, but there was no floating major tag to pin to instead — every consumer either pins an exact patch release and misses fixes, or points at `@master` and risks breaking changes.

## What

`create-major-tag.yml` runs on every published release and force-pushes a `vN` tag at that commit (e.g. `v1` after `1.2.3` ships), so a workflow can pin `uses: nullean/curb@v1` and follow every `1.x.y` release automatically, the same way `actions/checkout@v5` works. This is about the GitHub Action reference, not the container image tags (`edge`/`latest`/semver on `ghcr.io/nullean/curb`), which are unaffected.

## Verify

Not exercised until the next release is published; the workflow only runs on `release: published`.

Made with [Cursor](https://cursor.com)