### PR TITLE
Retry dotnet tool restore once on a cold-cache failure

### DIFF
--- a/build/scripts/Targets.fs
+++ b/build/scripts/Targets.fs
@@ -20,7 +20,16 @@ let private execResult binary args =
     let result = Proc.Start(binary, List.toArray args)
     result.ExitCode
 
-let private restoreTools = lazy(exec "dotnet" ["tool"; "restore"])
+/// dotnet/sdk#53783: on a cold tool-resolver cache (every fresh CI runner, every fresh container),
+/// restoring 2+ RID-specific tool packages in one manifest can misattribute one package's
+/// DotnetToolSettings.xml to another, failing with "The command ... is not contained in the
+/// package ...". The cache is warm after the first attempt, so a bare retry always succeeds -
+/// see https://github.com/dotnet/sdk/issues/53783.
+let private restoreTools =
+    lazy(
+        try exec "dotnet" ["tool"; "restore"]
+        with _ -> exec "dotnet" ["tool"; "restore"]
+    )
 
 let private currentVersion =
     lazy(


### PR DESCRIPTION
## Summary
- `dotnet tool restore` now retries once on failure: [dotnet/sdk#53783](https://github.com/dotnet/sdk/issues/53783) causes cold-cache restores of 2+ RID-specific tool packages in one manifest (`release-notes`, `nupkg-validator`, `assembly-differ` are all native-AOT now) to misattribute one package's `DotnetToolSettings.xml` to another - hit on every fresh CI runner or fresh container, before the resolver cache warms up. Found while chasing down the same failure in `assembly-differ`/`assembly-rewriter`/`nupkg-validator`'s own release pipelines.

## Test plan
- [x] `dotnet build build/scripts/scripts.fsproj -c Release` succeeds.

Made with [Cursor](https://cursor.com)