### PR TITLE
Keep a string literal's own line endings when printing it

### DIFF
--- a/src/Nullean.Curb.Core/Documents/Doc.cs
+++ b/src/Nullean.Curb.Core/Documents/Doc.cs
@@ -88,7 +88,8 @@ internal enum LineType : byte
 
 	/// <summary>
 	/// Always a newline, emitted at column 0 with no indent. Used inside verbatim and raw string
-	/// literals, whose content must not be re-indented.
+	/// literals, whose content must not be re-indented. <c>B</c> picks the ending — see
+	/// <see cref="Doc.ConfiguredEnding"/>.
 	/// </summary>
 	Literal = 3,
 }
@@ -168,6 +169,23 @@ internal readonly struct Doc
 {
 	/// <summary>Sentinel for <see cref="DocKind.Indent"/> meaning "dedent to column 0".</summary>
 	public const int IndentToRoot = int.MinValue;
+
+	/// <summary>
+	/// <c>B</c> on a <see cref="LineType.Literal"/> line: write the configured <c>end_of_line</c>.
+	/// </summary>
+	/// <remarks>
+	/// The default, and what a break between two lines of a comment, a doc comment or a disabled
+	/// <c>#if</c> branch wants: those newlines are layout, so normalising them is the whole point.
+	/// A newline that is part of a string literal's value is not layout, and asks for one of the two
+	/// below instead — rewriting it changes what the program computes.
+	/// </remarks>
+	public const int ConfiguredEnding = 0;
+
+	/// <summary><c>B</c> on a <see cref="LineType.Literal"/> line: write <c>\n</c> whatever the configuration says.</summary>
+	public const int LfEnding = 1;
+
+	/// <summary><c>B</c> on a <see cref="LineType.Literal"/> line: write <c>\r\n</c> whatever the configuration says.</summary>
+	public const int CrLfEnding = 2;
 
 	public readonly DocKind Kind;
 	public readonly DocFlags Flags;

--- a/src/Nullean.Curb.Core/Documents/DocArena.cs
+++ b/src/Nullean.Curb.Core/Documents/DocArena.cs
@@ -90,6 +90,17 @@ internal sealed class DocArena
 	public void LiteralLine(DocFlags flags = DocFlags.None) => AddLine(LineType.Literal, flags);
 
 	/// <summary>
+	/// A literal line that reproduces the ending the source had here rather than the configured one.
+	/// </summary>
+	/// <remarks>
+	/// For newlines that are part of a string literal's value. A raw or verbatim string's line
+	/// endings are content: rewriting them changes the string the program builds, and changes the
+	/// token's own text, which is why the re-parse comparer reports it as a changed token.
+	/// </remarks>
+	public void SourceLine(bool crLf) =>
+		Add(new Doc(DocKind.Line, a: (int)LineType.Literal, b: crLf ? Doc.CrLfEnding : Doc.LfEnding));
+
+	/// <summary>
 	/// A newline, but only when the group <paramref name="groupId"/> names ended up broken.
 	/// </summary>
 	/// <remarks>

--- a/src/Nullean.Curb.Core/Documents/DocDumper.cs
+++ b/src/Nullean.Curb.Core/Documents/DocDumper.cs
@@ -50,7 +50,12 @@ internal static class DocDumper
 						LineType.Normal => "line",
 						LineType.Soft => "softline",
 						LineType.Hard => "hardline",
-						LineType.Literal => "literalline",
+						LineType.Literal => doc.B switch
+						{
+							Doc.LfEnding => "literalline lf",
+							Doc.CrLfEnding => "literalline crlf",
+							_ => "literalline",
+						},
 						_ => "line?",
 					});
 					AppendFlags(output, doc.Flags);

--- a/src/Nullean.Curb.Core/Printing/CSharp/Printers.Expressions.cs
+++ b/src/Nullean.Curb.Core/Printing/CSharp/Printers.Expressions.cs
@@ -26,8 +26,9 @@ internal static partial class Printers
 		if (first.RawKind != 0)
 			TokenPrinter.PrintLeadingTrivia(first, context);
 
+		// preserveLineEndings: the run is a string literal, so its newlines are part of the value.
 		var span = node.Span;
-		TokenPrinter.EmitVerbatimRange(context, span.Start, span.Length);
+		TokenPrinter.EmitVerbatimRange(context, span.Start, span.Length, preserveLineEndings: true);
 
 		if (last.RawKind != 0)
 			TokenPrinter.PrintTrailingTrivia(last, context);

--- a/src/Nullean.Curb.Core/Printing/CSharp/TokenPrinter.cs
+++ b/src/Nullean.Curb.Core/Printing/CSharp/TokenPrinter.cs
@@ -555,7 +555,16 @@ internal static class TokenPrinter
 	/// Emits <paramref name="length"/> characters from <paramref name="start"/> exactly as written,
 	/// splitting on newlines so that the printer does not re-indent them.
 	/// </summary>
-	internal static void EmitVerbatimRange(PrintContext context, int start, int length)
+	/// <remarks>
+	/// <paramref name="preserveLineEndings"/> says the newlines in the range belong to the content
+	/// rather than to the layout, which is the case inside a string literal: an interpolated string
+	/// is printed as one verbatim run, and its line endings are characters of the value it builds.
+	/// Re-issuing them as the configured <c>end_of_line</c> rewrites the literal — an LF raw string
+	/// in a file formatted to CRLF came back with its string changed, and the re-parse comparer
+	/// reported it as a changed token (issue #85). Comments and disabled <c>#if</c> branches want the
+	/// opposite, and leave it false so their endings normalise with everything else.
+	/// </remarks>
+	internal static void EmitVerbatimRange(PrintContext context, int start, int length, bool preserveLineEndings = false)
 	{
 		var source = context.Text;
 		var arena = context.Arena;
@@ -568,13 +577,19 @@ internal static class TokenPrinter
 				continue;
 
 			var lineLength = i - lineStart;
-			// Drop a \r that belongs to this \n; the printer emits the configured line ending.
-			if (lineLength > 0 && source[lineStart + lineLength - 1] == '\r')
+			// Drop a \r that belongs to this \n; the printer, not the text leaf, emits the ending.
+			var crLf = lineLength > 0 && source[lineStart + lineLength - 1] == '\r';
+			if (crLf)
 				lineLength--;
 
 			if (lineLength > 0)
 				arena.SourceText(lineStart, lineLength);
-			arena.LiteralLine();
+
+			if (preserveLineEndings)
+				arena.SourceLine(crLf);
+			else
+				arena.LiteralLine();
+
 			lineStart = i + 1;
 		}
 

--- a/src/Nullean.Curb.Core/Printing/DocPrinter.cs
+++ b/src/Nullean.Curb.Core/Printing/DocPrinter.cs
@@ -84,16 +84,7 @@ internal sealed class DocPrinter
 		_depth = 0;
 		_lastSourceEnd = -1;
 		_insideLineComment = false;
-
-		// Verbatim runs are re-emitted line by line with the configured ending, so when that differs
-		// from the source's own ending the content of a multi-line string literal changes. The
-		// boundary tracking below cannot see that — but only files that actually contain a verbatim
-		// or raw string literal are at risk, so check for the relevant delimiters before forcing a
-		// round-trip parse.
-		var sourceNewLine = source.Span.IndexOf('\n');
-		var sourceUsesCrLf = sourceNewLine > 0 && source.Span[sourceNewLine - 1] == '\r';
-		RoundTripAtRisk = sourceNewLine >= 0 && sourceUsesCrLf != (_endOfLine == "\r\n")
-			&& HasVerbatimOrRawString(source.Span);
+		RoundTripAtRisk = false;
 
 		_breaks.Run(arena);
 		EnsureGroupModes(arena.Count);
@@ -368,7 +359,15 @@ internal sealed class DocPrinter
 		// indent because whatever it sits inside (a raw string) owns its own leading whitespace.
 		if (type == LineType.Literal)
 		{
-			_output.Append(_endOfLine);
+			// B says whose ending this is. A break between two lines of a comment or a disabled #if
+			// branch takes the configured one; a newline inside a string literal keeps the source's,
+			// because there it is a character of the value rather than layout.
+			_output.Append(doc.B switch
+			{
+				Doc.LfEnding => "\n",
+				Doc.CrLfEnding => "\r\n",
+				_ => _endOfLine,
+			});
 			_column = 0;
 			_insideLineComment = false;
 			return;
@@ -472,26 +471,6 @@ internal sealed class DocPrinter
 
 		if (WeldDetector.CanWeld(previous, text[0]))
 			RoundTripAtRisk = true;
-	}
-
-	/// <summary>
-	/// Returns true when the source contains at least one verbatim or raw string delimiter.
-	/// Only such strings have their line endings rewritten by the verbatim-run emitter, so only
-	/// they can have their token text changed when the configured line ending differs from the
-	/// source's own.
-	/// </summary>
-	private static bool HasVerbatimOrRawString(ReadOnlySpan<char> source)
-	{
-		// Fast exit: no double-quote means no string literals at all.
-		if (source.IndexOf('"') < 0)
-			return false;
-
-		// @"..." and $@"..." both contain the two-character sequence @" (in $@" it appears at
-		// offset 1), so one search covers both. @$"..." has @ followed by $ followed by ", so
-		// it requires its own check. Raw string literals start with """.
-		return source.Contains("@\"", StringComparison.Ordinal)
-			|| source.Contains("@$\"", StringComparison.Ordinal)
-			|| source.Contains("\"\"\"", StringComparison.Ordinal);
 	}
 
 	private void Emit(ReadOnlySpan<char> text, DocFlags flags, bool suppressWidth)

--- a/tests/Nullean.Curb.Tests/Formatting/Options/CoreOptionTests.cs
+++ b/tests/Nullean.Curb.Tests/Formatting/Options/CoreOptionTests.cs
@@ -123,6 +123,30 @@ public class CoreOptionTests : FormattingTest
 		$"public class C{Environment.NewLine}{{{Environment.NewLine}}}{Environment.NewLine}",
 		editorConfig: "end_of_line = auto");
 
+	// A string literal's newlines are characters of its value, not layout, so end_of_line does not
+	// reach inside one. Re-issuing them with the configured ending changed both the string the
+	// program builds and the token's own text, which made the file fail its own round-trip check
+	// (issue #85). Interpolated strings are the case that regressed: they print as one verbatim run
+	// rather than as a single token, so they took the line-splitting path the others never did.
+
+	[Test]
+	public Task An_interpolated_raw_string_keeps_its_own_line_endings() => FormatsExactly(
+		"class A\n{\n    string M(string x)\n    {\n        return $\"\"\"\n            <a>{x}</a>\n            \"\"\";\n    }\n}",
+		"class A\r\n{\r\n    string M(string x)\r\n    {\r\n        return $\"\"\"\n            <a>{x}</a>\n            \"\"\";\r\n    }\r\n}\r\n",
+		editorConfig: "end_of_line = crlf");
+
+	[Test]
+	public Task An_interpolated_verbatim_string_keeps_its_own_line_endings() => FormatsExactly(
+		"class A\r\n{\r\n    string M(int x)\r\n    {\r\n        return $@\"one{x}\r\ntwo\";\r\n    }\r\n}",
+		"class A\n{\n    string M(int x)\n    {\n        return $@\"one{x}\r\ntwo\";\n    }\n}\n",
+		editorConfig: "end_of_line = lf");
+
+	[Test]
+	public Task A_raw_string_keeps_its_own_line_endings() => FormatsExactly(
+		"class A\n{\n    string M()\n    {\n        return \"\"\"\n            <a>b</a>\n            \"\"\";\n    }\n}",
+		"class A\r\n{\r\n    string M()\r\n    {\r\n        return \"\"\"\n            <a>b</a>\n            \"\"\";\r\n    }\r\n}\r\n",
+		editorConfig: "end_of_line = crlf");
+
 	// ---- insert_final_newline ------------------------------------------------------------------
 
 	[Test]

--- a/tests/Nullean.Curb.Tests/Printing/RoundTripRiskTests.cs
+++ b/tests/Nullean.Curb.Tests/Printing/RoundTripRiskTests.cs
@@ -100,20 +100,39 @@ public class RoundTripRiskTests
 	}
 
 	[Test]
-	public async Task Fires_when_line_endings_are_being_rewritten()
+	public async Task Does_not_fire_merely_because_the_file_holds_a_multi_line_literal()
 	{
-		// Verbatim string content is re-emitted with the configured ending, which changes the value
-		// of a multi-line literal. Only files that actually contain a verbatim or raw string need
-		// the second parse — the guard prevents unnecessary re-parses on files that have none.
+		// A verbatim string's newlines are content, and DocArena.SourceLine now reproduces them, so
+		// a file whose endings differ from the configured one no longer has its literals rewritten
+		// and no longer owes a second parse for that reason alone. Before that, every mixed-ending
+		// file containing @" or """ paid for one.
 		var arena = new DocArena();
 		arena.SourceText(0, 3);
 
 		using var output = new OutputBuffer();
 		var printer = new DocPrinter();
-		// Source contains @" so HasVerbatimOrRawString fires; CRLF source with LF target triggers the risk.
 		printer.Print(arena, "@\"a\r\nb\"".AsMemory(), new FormatOptions { EndOfLine = EndOfLine.Lf }, output);
 
-		printer.RoundTripAtRisk.Should().BeTrue();
+		printer.RoundTripAtRisk.Should().BeFalse();
+		await Task.CompletedTask;
+	}
+
+	[Test]
+	public async Task A_source_line_keeps_its_own_ending_rather_than_the_configured_one()
+	{
+		var arena = new DocArena();
+		arena.SourceText(0, 3);
+		arena.SourceLine(crLf: true);
+		arena.SourceText(4, 3);
+		arena.SourceLine(crLf: false);
+		arena.SourceText(8, 1);
+
+		using var output = new OutputBuffer();
+		var printer = new DocPrinter();
+		printer.Print(arena, Source.AsMemory(), Options, output);
+
+		// Options say LF; both endings come from the document, not from the configuration.
+		output.ToString().Should().Be("out\r\nvar\na");
 		await Task.CompletedTask;
 	}
 


### PR DESCRIPTION
Fixes #85.

## What was wrong

`InterpolatedStringExpression` is the one multi-line literal Curb prints as a *verbatim run* rather than as a token. `TokenPrinter.EmitVerbatimRange` split that run at every `\n`, dropped the `\r`, and re-issued each break as a `LiteralLine` — that is, with the configured `end_of_line`.

Those newlines are not layout. They are characters of the value the literal builds, and they are part of the token's own text. Rewriting them changed the program, and the re-parse comparer was right to report it:

```
A.cs: formatting changed token 12: '$"""
' became '$"""
'
```

Both sides print the same because the only difference is an invisible `\r`.

Every other multi-line literal survives because Roslyn hands it over as a single token, which `TokenPrinter.Print` emits as one text leaf. So `"""` and `@""` were fine while `$"""` was not — which is the split the issue observed. It is not raw-string-specific either: `$@"one\ntwo"` fails identically.

The failure only fires when the literal's endings differ from the resolved `end_of_line`, which is why the issue saw 1 file out of 10 fail and the other 9 sit green.

## The fix

Give the document IR a literal line that reproduces the source's own ending, and use it for string content only.

| File | Change |
|---|---|
| `Doc.cs` | `B` on a `LineType.Literal` line now selects the ending: `ConfiguredEnding` / `LfEnding` / `CrLfEnding` |
| `DocArena.cs` | `SourceLine(bool crLf)` emits one |
| `DocPrinter.cs` | `PrintLine` honours it; the `HasVerbatimOrRawString` forced-reparse guard is gone (see below) |
| `TokenPrinter.cs` | `EmitVerbatimRange(..., preserveLineEndings)` |
| `Printers.Expressions.cs` | `VerbatimContent` passes `true` — the only caller that does |
| `DocDumper.cs` | dumps `literalline lf` / `literalline crlf` |

Comments, doc comments and disabled `#if` branches keep normalising their endings, which is what they want — that is what bought efcore its fixed points.

## Removing the forced re-parse

`DocPrinter.Print` forced a round-trip parse on every mixed-ending file containing `@"` or `"""`, for exactly this rewrite. With the rewrite gone the guard has nothing to find, so it goes too. On Curb's own sources with LF input and `end_of_line = crlf`, forced re-parses drop from 64 of 144 to 0, with byte-identical output.

This is a deliberate scope addition rather than part of the minimal fix. It reverts cleanly as its own hunk if you would rather keep it — `Fires_when_line_endings_are_being_rewritten` comes back with it.

## Verification

- The issue's repro formats to itself and exits 0. Layout newlines become CRLF; the literal's stay LF.
- Unit suite: 1205 passing. Two failures (`Renders_the_arena_as_an_indented_s_expression`, and the write-failure test that needs `C:\repo`) reproduce on unmodified `main` and are unrelated.
- Old vs. new binary over 144 repo files, LF source with `end_of_line = crlf`: byte-identical output.
- `curb check` over elastic/docs-builder (1,285 files, 41 containing `$"""`): 0 failed, 0 unparsable.
- Conformance against `dotnet format whitespace`, all four CI legs:

| Configuration | Result |
|---|---|
| reflow off | 1285/1285 (100.00%) |
| `--reflow` | 1285/1285 (100.00%) |
| `--width 120` | 1285/1285 (100.00%) |
| `--reflow --preserve` | 1285/1285 (100.00%) |

## Tests added

- `CoreOptionTests`: three `end_of_line` cases pinning that an interpolated raw string, an interpolated verbatim string, and a plain raw string each keep their own endings while the layout around them converts.
- `RoundTripRiskTests`: `SourceLine` beats the configured ending in both directions, and the risk flag no longer fires merely because a file holds a multi-line literal.
